### PR TITLE
feat: Phase 1 基盤レイヤー - エラーハンドリング基盤を実装

### DIFF
--- a/nyao/core/exceptions.py
+++ b/nyao/core/exceptions.py
@@ -1,0 +1,157 @@
+"""カスタム例外クラス
+
+Nyaoアプリケーション全体で使用する例外クラスを定義します。
+"""
+
+from typing import Any
+
+
+class NyaoException(Exception):  # noqa: N818
+    """Nyaoアプリケーションの基底例外
+
+    すべてのカスタム例外の基底クラスです。
+    """
+
+    def to_dict(self) -> dict[str, Any]:
+        """ログ出力用の辞書を生成
+
+        Returns:
+            例外情報を含む辞書
+        """
+        return {
+            "exception_type": self.__class__.__name__,
+            "message": str(self),
+        }
+
+    def is_retryable(self) -> bool:
+        """リトライ可能かどうか
+
+        Returns:
+            リトライ可能な場合True、そうでない場合False
+        """
+        return False
+
+
+class SlackAPIError(NyaoException):
+    """Slack API関連のエラー
+
+    Slack APIの呼び出しで発生したエラーを表します。
+    """
+
+    # リトライ可能なエラーコード
+    RETRYABLE_ERROR_CODES = {
+        "rate_limited",
+        "service_unavailable",
+        "internal_error",
+    }
+
+    def __init__(self, message: str, error_code: str | None = None):
+        """SlackAPIErrorを初期化
+
+        Args:
+            message: エラーメッセージ
+            error_code: Slack APIのエラーコード
+        """
+        super().__init__(message)
+        self.error_code = error_code
+
+    def to_dict(self) -> dict[str, Any]:
+        """ログ出力用の辞書を生成
+
+        Returns:
+            エラーコードを含む辞書
+        """
+        return {
+            **super().to_dict(),
+            "error_code": self.error_code,
+        }
+
+    def is_retryable(self) -> bool:
+        """リトライ可能かどうか
+
+        Returns:
+            エラーコードがリトライ可能な場合True
+        """
+        return self.error_code in self.RETRYABLE_ERROR_CODES
+
+
+class LLMAPIError(NyaoException):
+    """LLM API関連のエラー
+
+    LLM APIの呼び出しで発生したエラーを表します。
+    """
+
+    # リトライ可能なHTTPステータスコード
+    RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+    def __init__(
+        self,
+        message: str,
+        model: str | None = None,
+        status_code: int | None = None,
+    ):
+        """LLMAPIErrorを初期化
+
+        Args:
+            message: エラーメッセージ
+            model: 使用したモデル名
+            status_code: HTTPステータスコード
+        """
+        super().__init__(message)
+        self.model = model
+        self.status_code = status_code
+
+    def to_dict(self) -> dict[str, Any]:
+        """ログ出力用の辞書を生成
+
+        Returns:
+            モデル名とステータスコードを含む辞書
+        """
+        return {
+            **super().to_dict(),
+            "model": self.model,
+            "status_code": self.status_code,
+        }
+
+    def is_retryable(self) -> bool:
+        """リトライ可能かどうか
+
+        Returns:
+            ステータスコードがリトライ可能な場合True
+        """
+        return self.status_code in self.RETRYABLE_STATUS_CODES
+
+
+class ConfigurationError(NyaoException):
+    """設定関連のエラー
+
+    設定の読み込みや検証で発生したエラーを表します。
+    設定エラーはリトライ不可能です。
+    """
+
+    pass
+
+
+class ContextManagementError(NyaoException):
+    """コンテキスト管理関連のエラー
+
+    会話コンテキストの作成、更新、取得で発生したエラーを表します。
+    """
+
+    def __init__(self, message: str, retryable: bool = False):
+        """ContextManagementErrorを初期化
+
+        Args:
+            message: エラーメッセージ
+            retryable: リトライ可能かどうか
+        """
+        super().__init__(message)
+        self._retryable = retryable
+
+    def is_retryable(self) -> bool:
+        """リトライ可能かどうか
+
+        Returns:
+            リトライ可能な場合True
+        """
+        return self._retryable

--- a/nyao/utils/retry.py
+++ b/nyao/utils/retry.py
@@ -1,0 +1,120 @@
+"""リトライ機能
+
+非同期関数のリトライ実行とデコレータを提供します。
+"""
+
+import asyncio
+import functools
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar, cast
+
+from nyao.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+async def retry_async(
+    func: Callable[..., T | Awaitable[T]],
+    *args: Any,
+    max_retries: int = 3,
+    delay: float = 1.0,
+    backoff: float = 2.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+    **kwargs: Any,
+) -> T:
+    """非同期関数をリトライ実行
+
+    Args:
+        func: 実行する非同期関数
+        *args: 関数の位置引数
+        max_retries: 最大リトライ回数
+        delay: 初回リトライまでの待機時間（秒）
+        backoff: リトライごとの待機時間の倍率
+        exceptions: リトライ対象の例外タプル
+        **kwargs: 関数のキーワード引数
+
+    Returns:
+        関数の実行結果
+
+    Raises:
+        最後の試行で発生した例外
+    """
+    last_exception = None
+
+    func_name = getattr(func, "__name__", repr(func))
+
+    for attempt in range(max_retries + 1):
+        try:
+            if asyncio.iscoroutinefunction(func):
+                return await cast(Awaitable[T], func(*args, **kwargs))
+            else:
+                result = func(*args, **kwargs)
+                if asyncio.iscoroutine(result):
+                    return await cast(Awaitable[T], result)
+                return cast(T, result)
+        except exceptions as e:
+            last_exception = e
+
+            if attempt >= max_retries:
+                logger.error(
+                    "retry_exhausted",
+                    function=func_name,
+                    max_retries=max_retries,
+                    exception=str(e),
+                )
+                raise
+
+            wait_time = delay * (backoff**attempt)
+            logger.warning(
+                "retry_attempt",
+                function=func_name,
+                attempt=attempt + 1,
+                max_retries=max_retries,
+                wait_time=wait_time,
+                exception=str(e),
+            )
+
+            await asyncio.sleep(wait_time)
+
+    # ここには到達しないはずだが、型チェッカーのために必要
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("Unexpected retry loop exit")
+
+
+def with_retry(
+    max_retries: int = 3,
+    delay: float = 1.0,
+    backoff: float = 2.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> Callable:
+    """リトライ機能を関数に適用するデコレータ
+
+    Args:
+        max_retries: 最大リトライ回数
+        delay: 初回リトライまでの待機時間（秒）
+        backoff: リトライごとの待機時間の倍率
+        exceptions: リトライ対象の例外タプル
+
+    Returns:
+        デコレートされた関数
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            return await retry_async(
+                func,
+                *args,
+                max_retries=max_retries,
+                delay=delay,
+                backoff=backoff,
+                exceptions=exceptions,
+                **kwargs,
+            )
+
+        return wrapper
+
+    return decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
 ]
-ignore = []
+ignore = [
+    "UP047", # Generic function should use type parameters
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,202 @@
+"""カスタム例外クラスのテストコード"""
+
+from nyao.core.exceptions import (
+    ConfigurationError,
+    ContextManagementError,
+    LLMAPIError,
+    NyaoException,
+    SlackAPIError,
+)
+
+
+class TestNyaoException:
+    """NyaoException基底例外のテスト"""
+
+    def test_nyao_exception_basic(self):
+        """NyaoExceptionが作成できること"""
+        exc = NyaoException()
+        assert isinstance(exc, Exception)
+        assert isinstance(exc, NyaoException)
+
+    def test_nyao_exception_with_message(self):
+        """メッセージ付きでNyaoExceptionを作成できること"""
+        exc = NyaoException("Test error message")
+        assert str(exc) == "Test error message"
+
+    def test_nyao_exception_to_dict(self):
+        """to_dict()で辞書化できること"""
+        exc = NyaoException("Test error")
+        result = exc.to_dict()
+
+        assert isinstance(result, dict)
+        assert result["exception_type"] == "NyaoException"
+        assert result["message"] == "Test error"
+
+    def test_nyao_exception_is_not_retryable(self):
+        """基底例外はデフォルトでリトライ不可であること"""
+        exc = NyaoException("Test error")
+        assert exc.is_retryable() is False
+
+
+class TestSlackAPIError:
+    """SlackAPIErrorのテスト"""
+
+    def test_slack_api_error_with_error_code(self):
+        """SlackAPIErrorにerror_code属性があること"""
+        exc = SlackAPIError("Slack API error", error_code="rate_limited")
+
+        assert str(exc) == "Slack API error"
+        assert exc.error_code == "rate_limited"
+
+    def test_slack_api_error_without_error_code(self):
+        """error_codeなしでSlackAPIErrorを作成できること"""
+        exc = SlackAPIError("Slack API error")
+
+        assert str(exc) == "Slack API error"
+        assert exc.error_code is None
+
+    def test_slack_api_error_retryable(self):
+        """リトライ可能なエラーコードを判定できること"""
+        # リトライ可能なエラーコード
+        retryable_codes = ["rate_limited", "service_unavailable", "internal_error"]
+        for code in retryable_codes:
+            exc = SlackAPIError("Test error", error_code=code)
+            assert exc.is_retryable() is True, f"{code} should be retryable"
+
+        # リトライ不可能なエラーコード
+        non_retryable_codes = ["invalid_auth", "channel_not_found", "not_in_channel"]
+        for code in non_retryable_codes:
+            exc = SlackAPIError("Test error", error_code=code)
+            assert exc.is_retryable() is False, f"{code} should not be retryable"
+
+    def test_slack_api_error_to_dict(self):
+        """to_dict()でerror_codeが含まれること"""
+        exc = SlackAPIError("Test error", error_code="rate_limited")
+        result = exc.to_dict()
+
+        assert result["exception_type"] == "SlackAPIError"
+        assert result["message"] == "Test error"
+        assert result["error_code"] == "rate_limited"
+
+
+class TestLLMAPIError:
+    """LLMAPIErrorのテスト"""
+
+    def test_llm_api_error_with_model_and_status(self):
+        """LLMAPIErrorにmodel/status_code属性があること"""
+        exc = LLMAPIError("LLM API error", model="openai/gpt-4o", status_code=429)
+
+        assert str(exc) == "LLM API error"
+        assert exc.model == "openai/gpt-4o"
+        assert exc.status_code == 429
+
+    def test_llm_api_error_without_optional_params(self):
+        """オプショナルパラメータなしでLLMAPIErrorを作成できること"""
+        exc = LLMAPIError("LLM API error")
+
+        assert str(exc) == "LLM API error"
+        assert exc.model is None
+        assert exc.status_code is None
+
+    def test_llm_api_error_retryable_status_codes(self):
+        """リトライ可能なステータスコードを判定できること"""
+        # リトライ可能なステータスコード
+        retryable_codes = [429, 500, 502, 503, 504]
+        for code in retryable_codes:
+            exc = LLMAPIError("Test error", status_code=code)
+            assert exc.is_retryable() is True, f"{code} should be retryable"
+
+        # リトライ不可能なステータスコード
+        non_retryable_codes = [400, 401, 403, 404]
+        for code in non_retryable_codes:
+            exc = LLMAPIError("Test error", status_code=code)
+            assert exc.is_retryable() is False, f"{code} should not be retryable"
+
+    def test_llm_api_error_to_dict(self):
+        """to_dict()でmodel/status_codeが含まれること"""
+        exc = LLMAPIError("Test error", model="openai/gpt-4o", status_code=429)
+        result = exc.to_dict()
+
+        assert result["exception_type"] == "LLMAPIError"
+        assert result["message"] == "Test error"
+        assert result["model"] == "openai/gpt-4o"
+        assert result["status_code"] == 429
+
+
+class TestConfigurationError:
+    """ConfigurationErrorのテスト"""
+
+    def test_configuration_error_not_retryable(self):
+        """ConfigurationErrorがリトライ不可であること"""
+        exc = ConfigurationError("Invalid configuration")
+
+        assert str(exc) == "Invalid configuration"
+        assert exc.is_retryable() is False
+
+
+class TestContextManagementError:
+    """ContextManagementErrorのテスト"""
+
+    def test_context_management_error(self):
+        """ContextManagementErrorが作成できること"""
+        exc = ContextManagementError("Context error")
+
+        assert str(exc) == "Context error"
+
+    def test_context_management_error_retryable(self):
+        """retryableパラメータでリトライ可能性を制御できること"""
+        # リトライ可能
+        exc_retryable = ContextManagementError("Context error", retryable=True)
+        assert exc_retryable.is_retryable() is True
+
+        # リトライ不可能（デフォルト）
+        exc_not_retryable = ContextManagementError("Context error")
+        assert exc_not_retryable.is_retryable() is False
+
+
+class TestExceptionInheritance:
+    """例外の継承関係のテスト"""
+
+    def test_exception_inheritance(self):
+        """すべての例外がNyaoExceptionを継承していること"""
+        exceptions = [
+            SlackAPIError("test"),
+            LLMAPIError("test"),
+            ConfigurationError("test"),
+            ContextManagementError("test"),
+        ]
+
+        for exc in exceptions:
+            assert isinstance(exc, NyaoException)
+            assert isinstance(exc, Exception)
+
+
+class TestExceptionStringRepresentation:
+    """例外の文字列表現のテスト"""
+
+    def test_exception_str_representation(self):
+        """例外の文字列表現が適切であること"""
+        exc1 = NyaoException("Base error")
+        assert str(exc1) == "Base error"
+
+        exc2 = SlackAPIError("Slack error", error_code="rate_limited")
+        assert str(exc2) == "Slack error"
+
+        exc3 = LLMAPIError("LLM error", model="gpt-4o", status_code=429)
+        assert str(exc3) == "LLM error"
+
+
+class TestExceptionWithCause:
+    """例外の原因保持のテスト"""
+
+    def test_exception_with_cause(self):
+        """原因となる例外を保持できること"""
+        try:
+            try:
+                raise ValueError("Original error")
+            except ValueError as e:
+                raise NyaoException("Wrapped error") from e
+        except NyaoException as exc:
+            assert str(exc) == "Wrapped error"
+            assert isinstance(exc.__cause__, ValueError)
+            assert str(exc.__cause__) == "Original error"

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,281 @@
+"""リトライ機能のテストコード"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nyao.utils.retry import retry_async, with_retry
+
+
+class CustomError(Exception):
+    """テスト用のカスタムエラー"""
+
+    pass
+
+
+class AnotherError(Exception):
+    """テスト用の別のエラー"""
+
+    pass
+
+
+class TestRetryAsyncBasic:
+    """retry_async関数の基本機能のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_retry_async_success_on_first_attempt(self):
+        """初回で成功する関数がリトライされないこと"""
+        mock_func = AsyncMock(return_value="success")
+
+        result = await retry_async(mock_func, max_retries=3)
+
+        assert result == "success"
+        assert mock_func.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_async_success_after_retries(self):
+        """リトライ後に成功すること"""
+        mock_func = AsyncMock(
+            side_effect=[CustomError("Error 1"), CustomError("Error 2"), "success"]
+        )
+
+        result = await retry_async(mock_func, max_retries=3, delay=0.01, exceptions=(CustomError,))
+
+        assert result == "success"
+        assert mock_func.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_async_exhausts_retries(self):
+        """最大リトライ回数を超えたら例外が送出されること"""
+        mock_func = AsyncMock(side_effect=CustomError("Persistent error"))
+
+        with pytest.raises(CustomError, match="Persistent error"):
+            await retry_async(mock_func, max_retries=2, delay=0.01, exceptions=(CustomError,))
+
+        # max_retries=2の場合、初回 + 2回のリトライ = 3回呼び出し
+        assert mock_func.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_async_with_different_exception(self):
+        """指定外の例外は即座に送出されること"""
+        mock_func = AsyncMock(side_effect=AnotherError("Different error"))
+
+        with pytest.raises(AnotherError, match="Different error"):
+            await retry_async(mock_func, max_retries=3, delay=0.01, exceptions=(CustomError,))
+
+        # リトライされずに即座に例外が送出されるので、1回のみ呼び出し
+        assert mock_func.call_count == 1
+
+
+class TestRetryAsyncBackoff:
+    """retry_asyncのバックオフ検証のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_retry_async_backoff_timing(self):
+        """指数バックオフが正しく動作すること"""
+        mock_func = AsyncMock(
+            side_effect=[CustomError("Error 1"), CustomError("Error 2"), "success"]
+        )
+
+        start_time = asyncio.get_event_loop().time()
+        result = await retry_async(
+            mock_func, max_retries=3, delay=0.1, backoff=2.0, exceptions=(CustomError,)
+        )
+        elapsed_time = asyncio.get_event_loop().time() - start_time
+
+        assert result == "success"
+        # 1回目のリトライ: 0.1秒, 2回目のリトライ: 0.2秒
+        # 合計: 0.3秒以上（多少の誤差を考慮）
+        assert elapsed_time >= 0.25
+
+    @pytest.mark.asyncio
+    async def test_retry_async_custom_delay(self):
+        """カスタム遅延時間が使用されること"""
+        mock_func = AsyncMock(side_effect=[CustomError("Error"), "success"])
+
+        start_time = asyncio.get_event_loop().time()
+        result = await retry_async(mock_func, max_retries=3, delay=0.05, exceptions=(CustomError,))
+        elapsed_time = asyncio.get_event_loop().time() - start_time
+
+        assert result == "success"
+        # 0.05秒以上待機している
+        assert elapsed_time >= 0.04
+
+    @pytest.mark.asyncio
+    async def test_retry_async_custom_backoff(self):
+        """カスタムバックオフ倍率が使用されること"""
+        mock_func = AsyncMock(
+            side_effect=[
+                CustomError("Error 1"),
+                CustomError("Error 2"),
+                CustomError("Error 3"),
+                "success",
+            ]
+        )
+
+        start_time = asyncio.get_event_loop().time()
+        result = await retry_async(
+            mock_func, max_retries=4, delay=0.05, backoff=3.0, exceptions=(CustomError,)
+        )
+        elapsed_time = asyncio.get_event_loop().time() - start_time
+
+        assert result == "success"
+        # 1回目: 0.05秒, 2回目: 0.15秒, 3回目: 0.45秒
+        # 合計: 0.65秒以上
+        assert elapsed_time >= 0.60
+
+
+class TestWithRetryDecorator:
+    """with_retryデコレータのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_with_retry_decorator_basic(self):
+        """デコレータが基本的に機能すること"""
+        call_count = 0
+
+        @with_retry(max_retries=3, delay=0.01, exceptions=(CustomError,))
+        async def test_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise CustomError("Retry me")
+            return "success"
+
+        result = await test_func()
+
+        assert result == "success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_with_retry_decorator_with_params(self):
+        """デコレータにパラメータを渡せること"""
+
+        @with_retry(max_retries=2, delay=0.01, backoff=2.0, exceptions=(CustomError,))
+        async def test_func():
+            raise CustomError("Always fails")
+
+        with pytest.raises(CustomError):
+            await test_func()
+
+    @pytest.mark.asyncio
+    async def test_with_retry_decorator_preserves_function_metadata(self):
+        """関数のメタデータが保持されること"""
+
+        @with_retry(max_retries=3, delay=0.01)
+        async def test_func():
+            """Test function docstring"""
+            return "success"
+
+        assert test_func.__name__ == "test_func"
+        assert test_func.__doc__ == "Test function docstring"
+
+
+class TestRetryAsyncMultipleExceptions:
+    """retry_asyncの複数例外対応のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_retry_async_multiple_exceptions(self):
+        """複数の例外タイプを指定できること"""
+        mock_func = AsyncMock(
+            side_effect=[CustomError("Error 1"), AnotherError("Error 2"), "success"]
+        )
+
+        result = await retry_async(
+            mock_func,
+            max_retries=3,
+            delay=0.01,
+            exceptions=(CustomError, AnotherError),
+        )
+
+        assert result == "success"
+        assert mock_func.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_async_exception_hierarchy(self):
+        """例外階層が正しく処理されること"""
+
+        class ParentError(Exception):
+            pass
+
+        class ChildError(ParentError):
+            pass
+
+        mock_func = AsyncMock(side_effect=[ChildError("Child error"), "success"])
+
+        # 親クラスを指定した場合、子クラスの例外もキャッチされる
+        result = await retry_async(mock_func, max_retries=3, delay=0.01, exceptions=(ParentError,))
+
+        assert result == "success"
+        assert mock_func.call_count == 2
+
+
+class TestRetryAsyncWithAsyncFunction:
+    """retry_asyncの非同期関数対応のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_retry_async_with_async_function(self):
+        """非同期関数が正しくリトライされること"""
+        call_count = 0
+
+        async def async_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise CustomError("Retry me")
+            return "async success"
+
+        result = await retry_async(async_func, max_retries=3, delay=0.01, exceptions=(CustomError,))
+
+        assert result == "async success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_async_with_args_and_kwargs(self):
+        """引数・キーワード引数が正しく渡されること"""
+        call_count = 0
+
+        async def async_func(arg1, arg2, kwarg1=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise CustomError("Retry me")
+            return f"{arg1}-{arg2}-{kwarg1}"
+
+        result = await retry_async(
+            async_func,
+            "value1",
+            "value2",
+            max_retries=3,
+            delay=0.01,
+            exceptions=(CustomError,),
+            kwarg1="kwvalue",
+        )
+
+        assert result == "value1-value2-kwvalue"
+        assert call_count == 2
+
+
+class TestRetryAsyncEdgeCases:
+    """retry_asyncのエッジケースのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_retry_async_max_retries_zero(self):
+        """max_retries=0でリトライされないこと"""
+        mock_func = AsyncMock(side_effect=CustomError("Error"))
+
+        with pytest.raises(CustomError):
+            await retry_async(mock_func, max_retries=0, delay=0.01, exceptions=(CustomError,))
+
+        # max_retries=0の場合、初回のみ呼び出し
+        assert mock_func.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_async_with_no_exception(self):
+        """例外が発生しない場合、即座に結果を返すこと"""
+        mock_func = AsyncMock(return_value="immediate success")
+
+        result = await retry_async(mock_func, max_retries=3, delay=0.01)
+
+        assert result == "immediate success"
+        assert mock_func.call_count == 1


### PR DESCRIPTION
## 概要

Phase 1 基盤レイヤーの最後のコンポーネントである**エラーハンドリング基盤**を実装しました。

specs/phase-1/01-foundation.md の Error Handling セクションの要件に基づき、カスタム例外クラスとリトライ機能をTDD（テスト駆動開発）で実装しています。

## 実装内容

### 1. カスタム例外クラス (`nyao/core/exceptions.py`)

- **NyaoException**: 基底例外
  - `to_dict()`: ログ出力用の辞書を生成
  - `is_retryable()`: リトライ可能かどうかを判定

- **SlackAPIError**: Slack API関連のエラー
  - 属性: `error_code`
  - リトライ可能なエラーコード: `rate_limited`, `service_unavailable`, `internal_error`

- **LLMAPIError**: LLM API関連のエラー
  - 属性: `model`, `status_code`
  - リトライ可能なステータスコード: 429, 500, 502, 503, 504

- **ConfigurationError**: 設定関連のエラー（リトライ不可）

- **ContextManagementError**: コンテキスト管理関連のエラー
  - 属性: `retryable`（リトライ可否を制御可能）

### 2. リトライ機能 (`nyao/utils/retry.py`)

- **`retry_async()`**: 非同期関数のリトライ実行
  - 指数バックオフ機能（delay × backoff^attempt）
  - ロギングシステムとの統合
  - 型安全な実装

- **`@with_retry`**: リトライ機能を適用するデコレータ
  - 関数のメタデータを保持（`functools.wraps`）
  - カスタマイズ可能なパラメータ

### 3. テストコード

- **`tests/test_exceptions.py`**: 18テストケース
  - 例外の作成、継承、属性、リトライ可否判定などをテスト

- **`tests/test_retry.py`**: 16テストケース
  - リトライ動作、バックオフ、デコレータ、複数例外対応などをテスト

## テスト結果

✅ **すべてのテスト（100個）が成功**

```
tests/test_config.py: 13 passed
tests/test_exceptions.py: 18 passed
tests/test_logging.py: 31 passed
tests/test_models.py: 22 passed
tests/test_retry.py: 16 passed
```

## コード品質チェック

✅ **すべてのチェックが合格**

- `ruff check .` - コードスタイルチェック
- `ruff format --check .` - フォーマットチェック
- `ty check .` - 型チェック

## Phase 1 基盤レイヤーの完成

これにより、Phase 1 基盤レイヤーの4つのコンポーネントがすべて完成しました：

1. ✅ 設定管理システム (`nyao/config/settings.py`)
2. ✅ ロギングシステム (`nyao/core/logging.py`)
3. ✅ データモデル定義 (`nyao/core/models.py`)
4. ✅ エラーハンドリング基盤 (`nyao/core/exceptions.py`, `nyao/utils/retry.py`)

## 使用例

```python
from nyao.core.exceptions import SlackAPIError, LLMAPIError
from nyao.utils.retry import with_retry

# Slack API呼び出しにリトライを適用
@with_retry(
    max_retries=3,
    delay=1.0,
    backoff=2.0,
    exceptions=(SlackAPIError,)
)
async def fetch_message(channel_id: str):
    # Slack API呼び出し
    pass

# LLM API呼び出しにリトライを適用
@with_retry(
    max_retries=3,
    delay=2.0,
    backoff=2.0,
    exceptions=(LLMAPIError,)
)
async def generate_response(context):
    # LLM API呼び出し
    pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)