### PR TITLE
feat: LiteLLM設定をstrands-agents LiteLLMModel形式に変更

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -7,12 +7,16 @@ slack:
     - "C123456"
     - "C789012"
 
-# LLM設定（LiteLLMの設定を直接パススルー）
+# LLM設定（strands-agents LiteLLMModel形式）
 litellm:
-  model: "openai/gpt-4o"  # プロバイダー/モデル形式
-  api_key: "$OPENAI_API_KEY"  # プレフィックスに $ がついた場合は環境変数を設定する
-  temperature: 0.7
-  max_tokens: 1000
+  model_id: "openai/gpt-4o"  # 必須: プロバイダー/モデル形式
+  client_args:  # オプション: LiteLLMクライアント引数
+    api_key: "$OPENAI_API_KEY"  # $プレフィックスで環境変数を参照
+    # api_base: "https://api.example.com"  # カスタムAPIエンドポイント
+    # use_litellm_proxy: false  # LiteLLMプロキシ使用時はtrue
+  params:  # オプション: モデルパラメータ
+    temperature: 0.7
+    max_tokens: 1000
 
 # Bot動作設定
 bot:

--- a/nyao/config/settings.py
+++ b/nyao/config/settings.py
@@ -55,6 +55,14 @@ class LoggingSettings(BaseModel):
     )
 
 
+class LiteLLMSettings(BaseModel):
+    """LiteLLM設定（strands-agents LiteLLMModel形式）"""
+
+    model_id: str = Field(description="LiteLLMモデルID（プロバイダー/モデル形式）")
+    client_args: dict[str, Any] = Field(default_factory=dict, description="LiteLLMクライアント引数")
+    params: dict[str, Any] = Field(default_factory=dict, description="LiteLLMモデルパラメータ")
+
+
 class Settings(BaseSettings):
     """アプリケーション設定
 
@@ -75,7 +83,7 @@ class Settings(BaseSettings):
 
     # YAMLファイルから読み込む設定
     slack: SlackSettings
-    litellm: dict[str, Any]
+    litellm: LiteLLMSettings
     bot: BotSettings = Field(default_factory=BotSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
 

--- a/specs/phase-1/01-foundation.md
+++ b/specs/phase-1/01-foundation.md
@@ -47,12 +47,14 @@ slack:
     - "C123456"
     - "C789012"
 
-# LLM設定（LiteLLMの設定を直接パススルー）
+# LLM設定（strands-agents LiteLLMModel形式）
 litellm:
-  model: "openai/gpt-4o"  # プロバイダー/モデル形式
-  api_key: "$OPENAI_API_KEY"  # プレフィックスに `$` がついた場合は環境変数を設定する
-  temperature: 0.7
-  max_tokens: 1000
+  model_id: "openai/gpt-4o"  # 必須: プロバイダー/モデル形式
+  client_args:  # オプション: LiteLLMクライアント引数
+    api_key: "$OPENAI_API_KEY"  # $プレフィックスで環境変数を参照
+  params:  # オプション: モデルパラメータ
+    temperature: 0.7
+    max_tokens: 1000
 
 # Bot動作設定
 bot:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from nyao.config.settings import (
     BotSettings,
+    LiteLLMSettings,
     LoggingSettings,
     SlackSettings,
     get_response_delay_with_jitter,
@@ -27,7 +28,7 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -49,7 +50,10 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456", "C789012"]},
-            "litellm": {"model": "openai/gpt-4o", "temperature": 0.8, "max_tokens": 2000},
+            "litellm": {
+                "model_id": "openai/gpt-4o",
+                "params": {"temperature": 0.8, "max_tokens": 2000},
+            },
             "bot": {"response_delay": {"base": 90, "jitter": 20}, "persona": "テストペルソナ"},
             "logging": {"level": "DEBUG"},
         }
@@ -62,9 +66,9 @@ class TestSettings:
         settings = get_settings()
 
         assert settings.slack.channel_ids == ["C123456", "C789012"]
-        assert settings.litellm["model"] == "openai/gpt-4o"
-        assert settings.litellm["temperature"] == 0.8
-        assert settings.litellm["max_tokens"] == 2000
+        assert settings.litellm.model_id == "openai/gpt-4o"
+        assert settings.litellm.params["temperature"] == 0.8
+        assert settings.litellm.params["max_tokens"] == 2000
         assert settings.bot.response_delay.base == 90
         assert settings.bot.response_delay.jitter == 20
         assert settings.bot.persona == "テストペルソナ"
@@ -79,7 +83,10 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o", "api_key": "$OPENAI_API_KEY"},
+            "litellm": {
+                "model_id": "openai/gpt-4o",
+                "client_args": {"api_key": "$OPENAI_API_KEY"},
+            },
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -89,7 +96,7 @@ class TestSettings:
         reload_settings()
         settings = get_settings()
 
-        assert settings.litellm["api_key"] == "sk-test-key"
+        assert settings.litellm.client_args["api_key"] == "sk-test-key"
 
     def test_default_values_applied(self, tmp_path, monkeypatch):
         """デフォルト値が正しく適用されること"""
@@ -100,7 +107,7 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -124,7 +131,7 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -142,7 +149,7 @@ class TestSettings:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
             "bot": {"response_delay": {"base": 60, "jitter": 10}},
         }
         with open(config_file, "w") as f:
@@ -207,3 +214,32 @@ class TestLoggingSettings:
         """不正なログレベルが拒否されること"""
         with pytest.raises(ValidationError):
             LoggingSettings(level="INVALID")  # type: ignore[arg-type]
+
+
+class TestLiteLLMSettings:
+    """LiteLLM設定のテスト"""
+
+    def test_model_id_required(self):
+        """model_idが必須であること"""
+        with pytest.raises(ValidationError):
+            LiteLLMSettings()  # type: ignore[call-arg]
+
+    def test_minimal_config(self):
+        """最小限の設定（model_idのみ）で動作すること"""
+        settings = LiteLLMSettings(model_id="openai/gpt-4o")
+        assert settings.model_id == "openai/gpt-4o"
+        assert settings.client_args == {}
+        assert settings.params == {}
+
+    def test_full_config(self):
+        """すべてのフィールドが設定できること"""
+        settings = LiteLLMSettings(
+            model_id="openai/gpt-4o",
+            client_args={"api_key": "sk-test", "api_base": "https://api.example.com"},
+            params={"temperature": 0.7, "max_tokens": 1000},
+        )
+        assert settings.model_id == "openai/gpt-4o"
+        assert settings.client_args["api_key"] == "sk-test"
+        assert settings.client_args["api_base"] == "https://api.example.com"
+        assert settings.params["temperature"] == 0.7
+        assert settings.params["max_tokens"] == 1000

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -21,7 +21,7 @@ class TestLoggingSetup:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -52,7 +52,7 @@ class TestLoggingSetup:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -82,7 +82,7 @@ class TestLoggingSetup:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -112,7 +112,7 @@ class TestLoggingSetup:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -143,7 +143,7 @@ class TestLoggingSetup:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -177,7 +177,7 @@ class TestLogFormatting:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -217,7 +217,7 @@ class TestLogFormatting:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -254,7 +254,7 @@ class TestLogFormatting:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -290,7 +290,7 @@ class TestLogFormatting:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -322,7 +322,7 @@ class TestLogFormatting:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -358,7 +358,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -390,7 +390,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -422,7 +422,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -454,7 +454,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -486,7 +486,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -518,7 +518,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -550,7 +550,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -582,7 +582,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -615,7 +615,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -654,7 +654,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -693,7 +693,7 @@ class TestSensitiveDataMasking:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -731,7 +731,7 @@ class TestLogLevelFiltering:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -766,7 +766,7 @@ class TestLogLevelFiltering:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -801,7 +801,7 @@ class TestLogLevelFiltering:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -838,7 +838,7 @@ class TestLogLevelFiltering:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -875,7 +875,7 @@ class TestLogLevelFiltering:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -914,7 +914,7 @@ class TestContextInformation:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -949,7 +949,7 @@ class TestContextInformation:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)
@@ -988,7 +988,7 @@ class TestContextInformation:
         config_file = tmp_path / "config.yaml"
         config_data = {
             "slack": {"channel_ids": ["C123456"]},
-            "litellm": {"model": "openai/gpt-4o"},
+            "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
             yaml.dump(config_data, f)


### PR DESCRIPTION
## Summary

- strands-agentsのLiteLLMModelコンストラクタに合わせて、Config ManagerのLiteLLM設定構造を変更
- `LiteLLMSettings`モデルを追加（`model_id`, `client_args`, `params`）
- 設定ファイルの値をLiteLLMModelコンストラクタに直接渡せる構造に変更

### 変更前
```yaml
litellm:
  model: "openai/gpt-4o"
  api_key: "$OPENAI_API_KEY"
  temperature: 0.7
  max_tokens: 1000
```

### 変更後
```yaml
litellm:
  model_id: "openai/gpt-4o"
  client_args:
    api_key: "$OPENAI_API_KEY"
  params:
    temperature: 0.7
    max_tokens: 1000
```

## Test plan

- [x] すべてのユニットテストが通過すること（103件）
- [x] ruffによるリントチェックがパスすること
- [x] tyによる型チェックがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)