### PR TITLE
feat: 応答判定エージェント（ResponseJudgeAgent）を実装

### DIFF
--- a/nyao/integrations/llm/__init__.py
+++ b/nyao/integrations/llm/__init__.py
@@ -4,5 +4,7 @@ strands-agentsとLiteLLMを使用したLLM連携機能を提供します。
 """
 
 from nyao.integrations.llm.agent_base import NyaoAgent
+from nyao.integrations.llm.judge_agent import ResponseJudgeAgent
+from nyao.integrations.llm.prompts import PromptManager
 
-__all__ = ["NyaoAgent"]
+__all__ = ["NyaoAgent", "PromptManager", "ResponseJudgeAgent"]

--- a/nyao/integrations/llm/agent_base.py
+++ b/nyao/integrations/llm/agent_base.py
@@ -4,8 +4,9 @@ strands-agentsをラップしたNyaoAgentクラスを提供します。
 """
 
 import asyncio
-from typing import Any
+from typing import Any, TypeVar, cast
 
+from pydantic import BaseModel
 from strands import Agent
 from strands.models.litellm import LiteLLMModel
 
@@ -14,6 +15,8 @@ from nyao.core.exceptions import LLMAPIError
 from nyao.core.logging import get_logger
 from nyao.core.models import LLMResponse
 from nyao.utils.retry import retry_async
+
+T = TypeVar("T", bound=BaseModel)
 
 logger = get_logger(__name__)
 
@@ -226,3 +229,126 @@ class NyaoAgent:
                 if isinstance(first_content, dict) and "text" in first_content:
                     return first_content["text"]
         return ""
+
+    async def structured_output(
+        self,
+        output_model: type[T],
+        prompt: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> T:
+        """LLMを呼び出して構造化された出力を取得
+
+        strands-agentsのstructured_output機能を使用して、
+        Pydanticモデルに基づいた型安全な出力を取得します。
+
+        Args:
+            output_model: 出力のPydanticモデルクラス
+            prompt: ユーザープロンプト文字列
+            temperature: 温度パラメータ（Noneの場合は設定のデフォルト）
+            max_tokens: 最大トークン数（Noneの場合は設定のデフォルト）
+
+        Returns:
+            output_modelのインスタンス
+
+        Raises:
+            LLMAPIError: API呼び出しエラー時
+        """
+        logger.debug(
+            "structured_output_start",
+            output_model=output_model.__name__,
+            prompt_length=len(prompt),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+        # temperature/max_tokensが指定されていれば設定を更新
+        if temperature is not None or max_tokens is not None:
+            config_update: dict[str, Any] = {}
+            if temperature is not None:
+                config_update["temperature"] = temperature
+            if max_tokens is not None:
+                config_update["max_tokens"] = max_tokens
+            self._model.update_config(**config_update)
+
+        try:
+            # リトライ付きでstructured_output呼び出し
+            result = await self._structured_output_with_retry(output_model, prompt)
+
+            logger.debug(
+                "structured_output_success",
+                output_model=output_model.__name__,
+            )
+
+            return result
+
+        except LLMAPIError:
+            # 既にLLMAPIErrorの場合はそのまま再送出
+            raise
+        except Exception as e:
+            # その他の例外をLLMAPIErrorに変換
+            status_code = getattr(e, "status_code", None)
+            logger.error(
+                "structured_output_error",
+                error=str(e),
+                model=self._settings.model_id,
+                status_code=status_code,
+            )
+            raise LLMAPIError(
+                message=str(e),
+                model=self._settings.model_id,
+                status_code=status_code,
+            ) from e
+
+    async def _structured_output_with_retry(
+        self,
+        output_model: type[T],
+        prompt: str,
+    ) -> T:
+        """リトライ付きでAgent.structured_outputを呼び出す
+
+        Args:
+            output_model: 出力のPydanticモデルクラス
+            prompt: ユーザープロンプト
+
+        Returns:
+            output_modelのインスタンス
+
+        Raises:
+            LLMAPIError: リトライ不可能なエラーの場合
+            Exception: リトライ可能なエラーで最大リトライ回数を超えた場合
+        """
+
+        async def call_structured_output() -> T:
+            try:
+                # 同期的なAgent.structured_outputを非同期化
+                result = await asyncio.to_thread(
+                    self._agent.structured_output, output_model, prompt
+                )
+                return cast(T, result)
+            except Exception as e:
+                # ステータスコードを確認してリトライ可能か判定
+                status_code = getattr(e, "status_code", None)
+                if status_code is not None and not self._is_retryable_status(status_code):
+                    # リトライ不可能なエラーは_NonRetryableErrorでラップ
+                    llm_error = LLMAPIError(
+                        message=str(e),
+                        model=self._settings.model_id,
+                        status_code=status_code,
+                    )
+                    raise _NonRetryableError(llm_error) from e
+                raise
+
+        try:
+            result = await retry_async(
+                call_structured_output,
+                max_retries=self.MAX_RETRIES,
+                delay=self.RETRY_DELAY,
+                backoff=self.RETRY_BACKOFF,
+                exceptions=(Exception,),
+                skip_on=lambda e: getattr(e, "skip_retry", False),
+            )
+            return cast(T, result)
+        except _NonRetryableError as e:
+            # リトライ不可能なエラーは元のLLMAPIErrorをスロー
+            raise e.llm_error from e

--- a/nyao/integrations/llm/judge_agent.py
+++ b/nyao/integrations/llm/judge_agent.py
@@ -1,0 +1,133 @@
+"""応答判定エージェント
+
+Slackメッセージに対して応答すべきかどうかを判定するエージェントを提供します。
+"""
+
+from nyao.config.settings import LiteLLMSettings
+from nyao.core.exceptions import LLMAPIError
+from nyao.core.logging import get_logger
+from nyao.core.models import ResponseDecision, SlackMessage
+from nyao.integrations.llm.agent_base import NyaoAgent
+from nyao.integrations.llm.prompts import PromptManager
+
+logger = get_logger(__name__)
+
+
+class ResponseJudgeAgent:
+    """応答判定エージェント
+
+    Slackメッセージに対して応答すべきかどうかを判定します。
+    LLMを使用して判定を行い、エラー時は安全側（応答しない）に倒します。
+    strands-agentsのStructured Output機能を使用して、型安全な判定結果を取得します。
+    """
+
+    # LLM呼び出しパラメータ
+    TEMPERATURE = 0.3  # 一貫性を重視
+    MAX_TOKENS = 200
+
+    def __init__(
+        self,
+        settings: LiteLLMSettings,
+        persona: str | None = None,
+    ) -> None:
+        """ResponseJudgeAgentを初期化
+
+        Args:
+            settings: LiteLLM設定
+            persona: ボットのペルソナ設定（オプション）
+        """
+        self._settings = settings
+        self._prompt_manager = PromptManager(persona=persona)
+        self._agent = NyaoAgent(settings=settings)
+
+        logger.info(
+            "response_judge_agent_initialized",
+            model_id=settings.model_id,
+            has_custom_persona=persona is not None,
+        )
+
+    async def judge_should_respond(
+        self,
+        message: SlackMessage,
+        elapsed_seconds: int,
+        reaction_count: int,
+        reply_count: int,
+    ) -> ResponseDecision:
+        """メッセージに対して応答すべきかどうかを判定
+
+        strands-agentsのStructured Output機能を使用して、
+        ResponseDecisionモデルに基づいた型安全な判定結果を取得します。
+
+        Args:
+            message: 判定対象のSlackメッセージ
+            elapsed_seconds: メッセージ投稿からの経過秒数
+            reaction_count: リアクション数
+            reply_count: 返信数
+
+        Returns:
+            ResponseDecision: 判定結果
+        """
+        logger.debug(
+            "judge_should_respond_start",
+            message_id=message.message_id,
+            elapsed_seconds=elapsed_seconds,
+            reaction_count=reaction_count,
+            reply_count=reply_count,
+        )
+
+        try:
+            # プロンプトを構築
+            prompt = self._prompt_manager.build_should_respond_prompt(
+                message=message,
+                elapsed_seconds=elapsed_seconds,
+                reaction_count=reaction_count,
+                reply_count=reply_count,
+            )
+
+            # Structured Outputを使用してLLMを呼び出し
+            decision = await self._agent.structured_output(
+                output_model=ResponseDecision,
+                prompt=prompt,
+                temperature=self.TEMPERATURE,
+                max_tokens=self.MAX_TOKENS,
+            )
+
+            logger.info(
+                "judge_should_respond_success",
+                message_id=message.message_id,
+                should_respond=decision.should_respond,
+                confidence=decision.confidence,
+            )
+
+            return decision
+
+        except LLMAPIError as e:
+            logger.warning(
+                "judge_should_respond_llm_error",
+                message_id=message.message_id,
+                error=str(e),
+            )
+            return self._create_fallback_decision("LLMエラーにより判定不可")
+
+        except Exception as e:
+            logger.error(
+                "judge_should_respond_unexpected_error",
+                message_id=message.message_id,
+                error=str(e),
+            )
+            return self._create_fallback_decision(f"予期しないエラー: {e}")
+
+    def _create_fallback_decision(self, reason: str) -> ResponseDecision:
+        """フォールバック用のResponseDecisionを作成
+
+        Args:
+            reason: フォールバック理由
+
+        Returns:
+            ResponseDecision: 応答しない判定
+        """
+        return ResponseDecision(
+            should_respond=False,
+            reason=reason,
+            confidence=0.0,
+        )

--- a/nyao/integrations/llm/prompts.py
+++ b/nyao/integrations/llm/prompts.py
@@ -1,0 +1,153 @@
+"""プロンプト管理
+
+応答判定・応答生成のためのプロンプトテンプレートを管理します。
+"""
+
+from nyao.core.models import ConversationContext, SlackMessage
+
+DEFAULT_PERSONA = """にゃおは、Slackワークスペースで友達のように接するチャットボットです。
+カジュアルで親しみやすい口調で会話し、ユーザーが孤独を感じないようにサポートします。
+ただし、押しつけがましくならないよう、適度な距離感を保ちます。"""
+
+
+SHOULD_RESPOND_PROMPT_TEMPLATE = """\
+あなたはSlackメッセージに対して応答すべきかどうかを判定するアシスタントです。
+
+## メッセージ情報
+- 投稿者: {user_name}
+- チャンネル: {channel_id}
+- メッセージ本文:
+```
+{text}
+```
+
+## 現在の状況
+- 経過時間: {elapsed_minutes}分（{elapsed_seconds}秒）
+- リアクション数: {reaction_count}
+- 返信数: {reply_count}
+
+## 判定基準
+
+### 応答すべき場合
+- 誰からも反応がなく、投稿者が孤独を感じている可能性がある
+- 質問や相談が含まれているが、誰も回答していない
+- 一定時間が経過しても反応がない
+
+### 応答すべきでない場合
+- 既に他のユーザーから反応（リアクションや返信）がある
+- ボットへの直接的なメンションでない業務連絡
+- 独り言や状況報告で反応を期待していない内容
+- システムメッセージやボットからのメッセージ
+
+上記の判定基準に基づいて、このメッセージに応答すべきかどうかを判定してください。
+判定理由と確信度（0.0〜1.0）も回答に含めてください。"""
+
+
+RESPONSE_GENERATION_PROMPT_TEMPLATE = """## あなたのペルソナ
+{persona}
+
+## 返信ガイドライン
+- カジュアルで親しみやすい口調を使う
+- 1〜3文程度で簡潔に返信する
+- 相手の気持ちに寄り添う
+- 押しつけがましくならない
+- 質問には適切に答える
+
+## 会話のコンテキスト
+{context}
+
+## 返信対象のメッセージ
+投稿者: {user_name}
+メッセージ:
+```
+{text}
+```
+
+上記のメッセージに対して、あなたのペルソナとして自然な返信を生成してください。
+返信のテキストのみを出力してください。"""
+
+
+class PromptManager:
+    """プロンプト管理クラス
+
+    応答判定・応答生成のためのプロンプトを構築します。
+    """
+
+    def __init__(self, persona: str | None = None) -> None:
+        """PromptManagerを初期化
+
+        Args:
+            persona: ボットのペルソナ設定（Noneの場合はデフォルトを使用）
+        """
+        self.persona = persona if persona is not None else DEFAULT_PERSONA
+
+    def build_should_respond_prompt(
+        self,
+        message: SlackMessage,
+        elapsed_seconds: int,
+        reaction_count: int,
+        reply_count: int,
+    ) -> str:
+        """応答判定用プロンプトを構築
+
+        Args:
+            message: 判定対象のSlackメッセージ
+            elapsed_seconds: メッセージ投稿からの経過秒数
+            reaction_count: リアクション数
+            reply_count: 返信数
+
+        Returns:
+            構築されたプロンプト文字列
+        """
+        elapsed_minutes = elapsed_seconds // 60
+
+        return SHOULD_RESPOND_PROMPT_TEMPLATE.format(
+            user_name=message.user_name,
+            channel_id=message.channel_id,
+            text=message.text,
+            elapsed_seconds=elapsed_seconds,
+            elapsed_minutes=elapsed_minutes,
+            reaction_count=reaction_count,
+            reply_count=reply_count,
+        )
+
+    def build_response_generation_prompt(
+        self,
+        message: SlackMessage,
+        context: ConversationContext | None = None,
+    ) -> str:
+        """応答生成用プロンプトを構築
+
+        Args:
+            message: 返信対象のSlackメッセージ
+            context: 会話コンテキスト（オプション）
+
+        Returns:
+            構築されたプロンプト文字列
+        """
+        context_str = self._format_context(context)
+
+        return RESPONSE_GENERATION_PROMPT_TEMPLATE.format(
+            persona=self.persona,
+            user_name=message.user_name,
+            text=message.text,
+            context=context_str,
+        )
+
+    def _format_context(self, context: ConversationContext | None) -> str:
+        """会話コンテキストを文字列にフォーマット
+
+        Args:
+            context: 会話コンテキスト
+
+        Returns:
+            フォーマットされたコンテキスト文字列
+        """
+        if context is None or not context.messages:
+            return "（会話履歴なし）"
+
+        lines = []
+        for msg in context.messages:
+            lines.append(f"- {msg.user_name}: {msg.text}")
+
+        return "\n".join(lines)

--- a/specs/phase-1/03-llm-integration.md
+++ b/specs/phase-1/03-llm-integration.md
@@ -213,7 +213,7 @@ LLM APIへの実際の通信は行わず、`unittest.mock.AsyncMock`と`patch`�
 ```toml
 [tool.uv.dependencies]
 strands-agents = "^0.1"  # エージェントフレームワーク
-litellm = "^1.0"  # LLMプロバイダー統合
+litellm = "^1.80"  # LLMプロバイダー統合
 openai = "^1.0"  # OpenAI API（LiteLLMの依存）
 anthropic = "^0.25"  # Anthropic Claude API
 ```

--- a/tests/integrations/llm/test_agent_base.py
+++ b/tests/integrations/llm/test_agent_base.py
@@ -249,6 +249,101 @@ class TestNyaoAgentRetry:
                 assert mock_agent_instance.call_count == 1
 
 
+class TestNyaoAgentStructuredOutput:
+    """structured_outputメソッドのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_structured_output_returns_pydantic_model(
+        self, litellm_settings: LiteLLMSettings
+    ):
+        """Pydanticモデルが返されること"""
+        from pydantic import BaseModel
+
+        class TestModel(BaseModel):
+            name: str
+            value: int
+
+        with patch("nyao.integrations.llm.agent_base.Agent") as mock_agent_class:
+            with patch("nyao.integrations.llm.agent_base.LiteLLMModel"):
+                mock_agent_instance = MagicMock()
+                mock_agent_instance.structured_output.return_value = TestModel(
+                    name="test", value=42
+                )
+                mock_agent_class.return_value = mock_agent_instance
+
+                agent = NyaoAgent(settings=litellm_settings)
+                result = await agent.structured_output(TestModel, "テストプロンプト")
+
+                assert isinstance(result, TestModel)
+                assert result.name == "test"
+                assert result.value == 42
+
+    @pytest.mark.asyncio
+    async def test_structured_output_passes_prompt(self, litellm_settings: LiteLLMSettings):
+        """promptがstrands.Agent.structured_outputに渡されること"""
+        from pydantic import BaseModel
+
+        class TestModel(BaseModel):
+            name: str
+
+        with patch("nyao.integrations.llm.agent_base.Agent") as mock_agent_class:
+            with patch("nyao.integrations.llm.agent_base.LiteLLMModel"):
+                mock_agent_instance = MagicMock()
+                mock_agent_instance.structured_output.return_value = TestModel(name="test")
+                mock_agent_class.return_value = mock_agent_instance
+
+                agent = NyaoAgent(settings=litellm_settings)
+                await agent.structured_output(TestModel, "テストプロンプト")
+
+                mock_agent_instance.structured_output.assert_called_once_with(
+                    TestModel, "テストプロンプト"
+                )
+
+    @pytest.mark.asyncio
+    async def test_structured_output_with_custom_temperature(
+        self, litellm_settings: LiteLLMSettings
+    ):
+        """カスタムtemperatureが使用されること"""
+        from pydantic import BaseModel
+
+        class TestModel(BaseModel):
+            name: str
+
+        with patch("nyao.integrations.llm.agent_base.Agent") as mock_agent_class:
+            with patch("nyao.integrations.llm.agent_base.LiteLLMModel") as mock_model_class:
+                mock_agent_instance = MagicMock()
+                mock_agent_instance.structured_output.return_value = TestModel(name="test")
+                mock_agent_class.return_value = mock_agent_instance
+
+                mock_model_instance = MagicMock()
+                mock_model_class.return_value = mock_model_instance
+
+                agent = NyaoAgent(settings=litellm_settings)
+                await agent.structured_output(TestModel, "テストプロンプト", temperature=0.3)
+
+                mock_model_instance.update_config.assert_called_once_with(temperature=0.3)
+
+    @pytest.mark.asyncio
+    async def test_structured_output_raises_llm_api_error(self, litellm_settings: LiteLLMSettings):
+        """エラー時にLLMAPIErrorがスローされること"""
+        from pydantic import BaseModel
+
+        class TestModel(BaseModel):
+            name: str
+
+        with patch("nyao.integrations.llm.agent_base.Agent") as mock_agent_class:
+            with patch("nyao.integrations.llm.agent_base.LiteLLMModel"):
+                mock_agent_instance = MagicMock()
+                error = _MockAPIError("API Error", 401)
+                mock_agent_instance.structured_output.side_effect = error
+                mock_agent_class.return_value = mock_agent_instance
+
+                agent = NyaoAgent(settings=litellm_settings)
+
+                with pytest.raises(LLMAPIError):
+                    await agent.structured_output(TestModel, "テストプロンプト")
+
+
 class TestNyaoAgentErrorHandling:
     """エラーハンドリングのテスト"""
 

--- a/tests/integrations/llm/test_judge_agent.py
+++ b/tests/integrations/llm/test_judge_agent.py
@@ -1,0 +1,273 @@
+"""応答判定エージェントのテスト
+
+ResponseJudgeAgentクラスのテストを行います。
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nyao.config.settings import LiteLLMSettings
+from nyao.core.exceptions import LLMAPIError
+from nyao.core.models import ResponseDecision, SlackMessage
+from nyao.integrations.llm.judge_agent import ResponseJudgeAgent
+
+
+@pytest.fixture
+def litellm_settings() -> LiteLLMSettings:
+    """テスト用LiteLLMSettings"""
+    return LiteLLMSettings(
+        model_id="gpt-4o-mini",
+        client_args={"api_key": "test-api-key"},
+        params={"temperature": 0.5, "max_tokens": 200},
+    )
+
+
+@pytest.fixture
+def sample_message() -> SlackMessage:
+    """テスト用SlackMessage"""
+    return SlackMessage(
+        message_id="msg-001",
+        channel_id="C12345678",
+        user_id="U12345678",
+        user_name="testuser",
+        text="今日は良い天気ですね！",
+        timestamp=datetime.now(UTC),
+        reactions=[],
+        reply_count=0,
+    )
+
+
+class TestResponseJudgeAgentInit:
+    """ResponseJudgeAgent初期化のテスト"""
+
+    def test_init_with_settings(self, litellm_settings: LiteLLMSettings) -> None:
+        """LiteLLMSettingsで初期化できること"""
+        agent = ResponseJudgeAgent(settings=litellm_settings)
+
+        assert agent is not None
+        assert agent._settings == litellm_settings
+
+    def test_init_with_custom_persona(self, litellm_settings: LiteLLMSettings) -> None:
+        """カスタムペルソナで初期化できること"""
+        custom_persona = "テスト用ペルソナ"
+        agent = ResponseJudgeAgent(settings=litellm_settings, persona=custom_persona)
+
+        assert agent._prompt_manager.persona == custom_persona
+
+
+class TestJudgeShouldRespond:
+    """judge_should_respondのテスト"""
+
+    @pytest.fixture
+    def agent(self, litellm_settings: LiteLLMSettings) -> ResponseJudgeAgent:
+        """テスト用ResponseJudgeAgent"""
+        return ResponseJudgeAgent(settings=litellm_settings)
+
+    @pytest.fixture
+    def valid_decision(self) -> ResponseDecision:
+        """有効なResponseDecision"""
+        return ResponseDecision(
+            should_respond=True,
+            reason="誰からも反応がないため、応答する必要がある",
+            confidence=0.85,
+        )
+
+    async def test_judge_returns_response_decision(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+        valid_decision: ResponseDecision,
+    ) -> None:
+        """判定結果がResponseDecisionで返されること"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.return_value = valid_decision
+
+            result = await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            assert isinstance(result, ResponseDecision)
+            assert result.should_respond is True
+            assert result.reason == "誰からも反応がないため、応答する必要がある"
+            assert result.confidence == 0.85
+
+    async def test_judge_with_should_not_respond(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """応答不要と判定されること"""
+        decision = ResponseDecision(
+            should_respond=False,
+            reason="既にリアクションがあるため",
+            confidence=0.9,
+        )
+
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.return_value = decision
+
+            result = await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=60,
+                reaction_count=3,
+                reply_count=1,
+            )
+
+            assert result.should_respond is False
+
+    async def test_judge_uses_correct_temperature(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+        valid_decision: ResponseDecision,
+    ) -> None:
+        """temperature=0.3でLLMを呼び出すこと"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.return_value = valid_decision
+
+            await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            mock_structured_output.assert_called_once()
+            _, kwargs = mock_structured_output.call_args
+            assert kwargs.get("temperature") == 0.3
+
+    async def test_judge_uses_correct_max_tokens(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+        valid_decision: ResponseDecision,
+    ) -> None:
+        """max_tokens=200でLLMを呼び出すこと"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.return_value = valid_decision
+
+            await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            mock_structured_output.assert_called_once()
+            _, kwargs = mock_structured_output.call_args
+            assert kwargs.get("max_tokens") == 200
+
+    async def test_judge_passes_response_decision_model(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+        valid_decision: ResponseDecision,
+    ) -> None:
+        """ResponseDecisionモデルがstructured_outputに渡されること"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.return_value = valid_decision
+
+            await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            mock_structured_output.assert_called_once()
+            _, kwargs = mock_structured_output.call_args
+            assert kwargs.get("output_model") == ResponseDecision
+
+
+class TestFallbackBehavior:
+    """フォールバック動作のテスト"""
+
+    @pytest.fixture
+    def agent(self, litellm_settings: LiteLLMSettings) -> ResponseJudgeAgent:
+        """テスト用ResponseJudgeAgent"""
+        return ResponseJudgeAgent(settings=litellm_settings)
+
+    async def test_fallback_on_llm_error(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """LLMエラー時にデフォルトで「応答しない」を返すこと"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.side_effect = LLMAPIError(
+                message="API Error",
+                model="gpt-4o-mini",
+                status_code=500,
+            )
+
+            result = await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            assert result.should_respond is False
+            assert "エラー" in result.reason
+
+    async def test_fallback_on_unexpected_error(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """予期しないエラー時にデフォルトで「応答しない」を返すこと"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.side_effect = ValueError("Unexpected error")
+
+            result = await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            assert result.should_respond is False
+            assert "エラー" in result.reason
+
+    async def test_fallback_confidence_is_zero(
+        self,
+        agent: ResponseJudgeAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """フォールバック時のconfidenceが0.0であること"""
+        with patch.object(
+            agent._agent, "structured_output", new_callable=AsyncMock
+        ) as mock_structured_output:
+            mock_structured_output.side_effect = LLMAPIError(
+                message="API Error",
+                model="gpt-4o-mini",
+                status_code=500,
+            )
+
+            result = await agent.judge_should_respond(
+                message=sample_message,
+                elapsed_seconds=300,
+                reaction_count=0,
+                reply_count=0,
+            )
+
+            assert result.confidence == 0.0

--- a/tests/integrations/llm/test_prompts.py
+++ b/tests/integrations/llm/test_prompts.py
@@ -1,0 +1,245 @@
+"""プロンプト管理のテスト
+
+PromptManagerクラスのテストを行います。
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from nyao.core.models import ConversationContext, SlackMessage
+from nyao.integrations.llm.prompts import PromptManager
+
+
+class TestPromptManagerInit:
+    """PromptManager初期化のテスト"""
+
+    def test_init_with_persona(self) -> None:
+        """ペルソナを指定して初期化できること"""
+        persona = "にゃおは友達のように接するチャットボットです"
+        manager = PromptManager(persona=persona)
+
+        assert manager.persona == persona
+
+    def test_init_with_default_persona(self) -> None:
+        """デフォルトペルソナで初期化できること"""
+        manager = PromptManager()
+
+        assert manager.persona is not None
+        assert len(manager.persona) > 0
+
+
+class TestBuildShouldRespondPrompt:
+    """build_should_respond_promptのテスト"""
+
+    @pytest.fixture
+    def manager(self) -> PromptManager:
+        """テスト用PromptManager"""
+        return PromptManager(persona="テスト用ペルソナ")
+
+    @pytest.fixture
+    def sample_message(self) -> SlackMessage:
+        """テスト用SlackMessage"""
+        return SlackMessage(
+            message_id="msg-001",
+            channel_id="C12345678",
+            user_id="U12345678",
+            user_name="testuser",
+            text="今日は良い天気ですね！",
+            timestamp=datetime.now(UTC),
+            reactions=["thumbsup"],
+            reply_count=0,
+        )
+
+    def test_prompt_contains_message_text(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトにメッセージ本文が含まれること"""
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=1,
+            reply_count=0,
+        )
+
+        assert sample_message.text in prompt
+
+    def test_prompt_contains_user_name(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトにユーザー名が含まれること"""
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=1,
+            reply_count=0,
+        )
+
+        assert sample_message.user_name in prompt
+
+    def test_prompt_contains_elapsed_time(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトに経過時間が含まれること"""
+        elapsed_seconds = 600
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=elapsed_seconds,
+            reaction_count=1,
+            reply_count=0,
+        )
+
+        # 分単位（10分）が含まれることを確認
+        assert "10" in prompt or "600" in prompt
+
+    def test_prompt_contains_reaction_count(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトにリアクション数が含まれること"""
+        reaction_count = 3
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=reaction_count,
+            reply_count=0,
+        )
+
+        assert str(reaction_count) in prompt
+
+    def test_prompt_contains_reply_count(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトに返信数が含まれること"""
+        reply_count = 2
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=0,
+            reply_count=reply_count,
+        )
+
+        assert str(reply_count) in prompt
+
+    def test_prompt_contains_judgment_criteria(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトに判定基準が含まれること"""
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=0,
+            reply_count=0,
+        )
+
+        # 判定基準が含まれていることを確認
+        assert "判定基準" in prompt
+        assert "応答すべき場合" in prompt
+        assert "応答すべきでない場合" in prompt
+
+    def test_prompt_requests_confidence(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """プロンプトが確信度を要求すること"""
+        prompt = manager.build_should_respond_prompt(
+            message=sample_message,
+            elapsed_seconds=300,
+            reaction_count=0,
+            reply_count=0,
+        )
+
+        assert "確信度" in prompt
+
+
+class TestBuildResponseGenerationPrompt:
+    """build_response_generation_promptのテスト"""
+
+    @pytest.fixture
+    def manager(self) -> PromptManager:
+        """テスト用PromptManager"""
+        return PromptManager(persona="にゃおは友達のように接するチャットボットです")
+
+    @pytest.fixture
+    def sample_message(self) -> SlackMessage:
+        """テスト用SlackMessage"""
+        return SlackMessage(
+            message_id="msg-001",
+            channel_id="C12345678",
+            user_id="U12345678",
+            user_name="testuser",
+            text="今日のランチ何食べよう？",
+            timestamp=datetime.now(UTC),
+        )
+
+    @pytest.fixture
+    def sample_context(self, sample_message: SlackMessage) -> ConversationContext:
+        """テスト用ConversationContext"""
+        past_message = SlackMessage(
+            message_id="msg-000",
+            channel_id="C12345678",
+            user_id="U87654321",
+            user_name="otheruser",
+            text="おはよう！",
+            timestamp=datetime.now(UTC),
+        )
+        context = ConversationContext(
+            channel_id="C12345678",
+            last_updated=datetime.now(UTC),
+            messages=[past_message, sample_message],
+        )
+        return context
+
+    def test_prompt_contains_persona(
+        self,
+        manager: PromptManager,
+        sample_message: SlackMessage,
+        sample_context: ConversationContext,
+    ) -> None:
+        """プロンプトにペルソナが含まれること"""
+        prompt = manager.build_response_generation_prompt(
+            message=sample_message,
+            context=sample_context,
+        )
+
+        assert manager.persona in prompt
+
+    def test_prompt_contains_target_message(
+        self,
+        manager: PromptManager,
+        sample_message: SlackMessage,
+        sample_context: ConversationContext,
+    ) -> None:
+        """プロンプトに返信対象メッセージが含まれること"""
+        prompt = manager.build_response_generation_prompt(
+            message=sample_message,
+            context=sample_context,
+        )
+
+        assert sample_message.text in prompt
+        assert sample_message.user_name in prompt
+
+    def test_prompt_contains_context_messages(
+        self,
+        manager: PromptManager,
+        sample_message: SlackMessage,
+        sample_context: ConversationContext,
+    ) -> None:
+        """プロンプトにコンテキストメッセージが含まれること"""
+        prompt = manager.build_response_generation_prompt(
+            message=sample_message,
+            context=sample_context,
+        )
+
+        # コンテキストの過去メッセージも含まれること
+        assert "おはよう" in prompt
+
+    def test_prompt_without_context(
+        self, manager: PromptManager, sample_message: SlackMessage
+    ) -> None:
+        """コンテキストなしでもプロンプトが構築できること"""
+        prompt = manager.build_response_generation_prompt(
+            message=sample_message,
+            context=None,
+        )
+
+        assert sample_message.text in prompt
+        assert manager.persona in prompt


### PR DESCRIPTION
## Summary

- strands-agentsのStructured Output機能を使用した応答判定エージェントを実装
- NyaoAgentに`structured_output`メソッドを追加し、型安全な構造化出力を取得
- PromptManagerクラスでプロンプトテンプレートを管理
- LLMエラー時は安全側（応答しない）にフォールバック

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `nyao/integrations/llm/agent_base.py` | `structured_output`メソッドを追加 |
| `nyao/integrations/llm/judge_agent.py` | ResponseJudgeAgentクラスを新規作成 |
| `nyao/integrations/llm/prompts.py` | PromptManagerクラスを新規作成 |
| `tests/integrations/llm/test_*.py` | 各コンポーネントのテストを追加 |

## Test plan

- [x] `uv run ruff check .` - リントチェックがパス
- [x] `uv run ruff format --check .` - フォーマットチェックがパス
- [x] `uv run ty check .` - 型チェックがパス
- [x] `uv run pytest` - 144件のテストがすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)