### PR TITLE
feat: 応答生成エージェント（ResponseGeneratorAgent）を実装

### DIFF
--- a/nyao/integrations/llm/__init__.py
+++ b/nyao/integrations/llm/__init__.py
@@ -4,7 +4,8 @@ strands-agentsとLiteLLMを使用したLLM連携機能を提供します。
 """
 
 from nyao.integrations.llm.agent_base import NyaoAgent
+from nyao.integrations.llm.generator_agent import ResponseGeneratorAgent
 from nyao.integrations.llm.judge_agent import ResponseJudgeAgent
 from nyao.integrations.llm.prompts import PromptManager
 
-__all__ = ["NyaoAgent", "PromptManager", "ResponseJudgeAgent"]
+__all__ = ["NyaoAgent", "PromptManager", "ResponseGeneratorAgent", "ResponseJudgeAgent"]

--- a/nyao/integrations/llm/generator_agent.py
+++ b/nyao/integrations/llm/generator_agent.py
@@ -1,0 +1,89 @@
+"""応答生成エージェント
+
+Slackメッセージに対して友達のように自然な返信を生成するエージェントを提供します。
+"""
+
+from nyao.config.settings import LiteLLMSettings
+from nyao.core.logging import get_logger
+from nyao.core.models import ConversationContext, LLMResponse, SlackMessage
+from nyao.integrations.llm.agent_base import NyaoAgent
+from nyao.integrations.llm.prompts import PromptManager
+
+logger = get_logger(__name__)
+
+
+class ResponseGeneratorAgent:
+    """応答生成エージェント
+
+    Slackメッセージに対して友達のように自然な返信を生成します。
+    LLMを使用して応答を生成し、エラー時はLLMAPIErrorをスローして上位レイヤーで処理します。
+    """
+
+    # LLM呼び出しパラメータ
+    TEMPERATURE = 0.8  # 多様性を重視
+    MAX_TOKENS = 300
+
+    def __init__(
+        self,
+        settings: LiteLLMSettings,
+        persona: str | None = None,
+    ) -> None:
+        """ResponseGeneratorAgentを初期化
+
+        Args:
+            settings: LiteLLM設定
+            persona: ボットのペルソナ設定（オプション）
+        """
+        self._settings = settings
+        self._prompt_manager = PromptManager(persona=persona)
+        self._agent = NyaoAgent(settings=settings)
+
+        logger.info(
+            "response_generator_agent_initialized",
+            model_id=settings.model_id,
+            has_custom_persona=persona is not None,
+        )
+
+    async def generate_response(
+        self,
+        message: SlackMessage,
+        context: ConversationContext | None = None,
+    ) -> LLMResponse:
+        """メッセージに対する応答を生成
+
+        Args:
+            message: 返信対象のSlackメッセージ
+            context: 会話コンテキスト（オプション）
+
+        Returns:
+            LLMResponse: 生成された応答
+
+        Raises:
+            LLMAPIError: API呼び出しエラー時
+        """
+        logger.debug(
+            "generate_response_start",
+            message_id=message.message_id,
+            has_context=context is not None,
+        )
+
+        # プロンプトを構築
+        prompt = self._prompt_manager.build_response_generation_prompt(
+            message=message,
+            context=context,
+        )
+
+        # LLMを呼び出し（エラーはそのままスロー）
+        response = await self._agent.call_llm(
+            prompt=prompt,
+            temperature=self.TEMPERATURE,
+            max_tokens=self.MAX_TOKENS,
+        )
+
+        logger.info(
+            "generate_response_success",
+            message_id=message.message_id,
+            content_length=len(response.content),
+        )
+
+        return response

--- a/tests/integrations/llm/test_generator_agent.py
+++ b/tests/integrations/llm/test_generator_agent.py
@@ -1,0 +1,208 @@
+"""応答生成エージェントのテスト
+
+ResponseGeneratorAgentクラスのテストを行います。
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nyao.config.settings import LiteLLMSettings
+from nyao.core.exceptions import LLMAPIError
+from nyao.core.models import ConversationContext, LLMResponse, SlackMessage
+from nyao.integrations.llm.generator_agent import ResponseGeneratorAgent
+
+
+@pytest.fixture
+def litellm_settings() -> LiteLLMSettings:
+    """テスト用LiteLLMSettings"""
+    return LiteLLMSettings(
+        model_id="gpt-4o-mini",
+        client_args={"api_key": "test-api-key"},
+        params={"temperature": 0.5, "max_tokens": 200},
+    )
+
+
+@pytest.fixture
+def sample_message() -> SlackMessage:
+    """テスト用SlackMessage"""
+    return SlackMessage(
+        message_id="msg-001",
+        channel_id="C12345678",
+        user_id="U12345678",
+        user_name="testuser",
+        text="今日は良い天気ですね！",
+        timestamp=datetime.now(UTC),
+        reactions=[],
+        reply_count=0,
+    )
+
+
+@pytest.fixture
+def sample_context(sample_message: SlackMessage) -> ConversationContext:
+    """テスト用ConversationContext"""
+    return ConversationContext(
+        channel_id="C12345678",
+        messages=[sample_message],
+        last_updated=datetime.now(UTC),
+    )
+
+
+class TestResponseGeneratorAgentInit:
+    """ResponseGeneratorAgent初期化のテスト"""
+
+    def test_init_with_settings(self, litellm_settings: LiteLLMSettings) -> None:
+        """LiteLLMSettingsで初期化できること"""
+        agent = ResponseGeneratorAgent(settings=litellm_settings)
+
+        assert agent is not None
+        assert agent._settings == litellm_settings
+
+    def test_init_with_custom_persona(self, litellm_settings: LiteLLMSettings) -> None:
+        """カスタムペルソナで初期化できること"""
+        custom_persona = "テスト用ペルソナ"
+        agent = ResponseGeneratorAgent(settings=litellm_settings, persona=custom_persona)
+
+        assert agent._prompt_manager.persona == custom_persona
+
+
+class TestGenerateResponse:
+    """generate_responseのテスト"""
+
+    @pytest.fixture
+    def agent(self, litellm_settings: LiteLLMSettings) -> ResponseGeneratorAgent:
+        """テスト用ResponseGeneratorAgent"""
+        return ResponseGeneratorAgent(settings=litellm_settings)
+
+    @pytest.fixture
+    def valid_llm_response(self) -> LLMResponse:
+        """有効なLLMResponse"""
+        return LLMResponse(
+            content="いい天気ですね！お出かけ日和ですよ。",
+            model="gpt-4o-mini",
+            usage={},
+            finish_reason="stop",
+        )
+
+    async def test_generate_returns_llm_response(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+        valid_llm_response: LLMResponse,
+    ) -> None:
+        """生成結果がLLMResponseで返されること"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.return_value = valid_llm_response
+
+            result = await agent.generate_response(message=sample_message)
+
+            assert isinstance(result, LLMResponse)
+            assert result.content == "いい天気ですね！お出かけ日和ですよ。"
+
+    async def test_generate_with_context(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+        sample_context: ConversationContext,
+        valid_llm_response: LLMResponse,
+    ) -> None:
+        """コンテキスト付きで生成できること"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.return_value = valid_llm_response
+
+            result = await agent.generate_response(message=sample_message, context=sample_context)
+
+            assert isinstance(result, LLMResponse)
+            mock_call_llm.assert_called_once()
+
+    async def test_generate_without_context(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+        valid_llm_response: LLMResponse,
+    ) -> None:
+        """コンテキストなしで生成できること"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.return_value = valid_llm_response
+
+            result = await agent.generate_response(message=sample_message)
+
+            assert isinstance(result, LLMResponse)
+            mock_call_llm.assert_called_once()
+
+    async def test_generate_uses_correct_temperature(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+        valid_llm_response: LLMResponse,
+    ) -> None:
+        """temperature=0.8でLLMを呼び出すこと"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.return_value = valid_llm_response
+
+            await agent.generate_response(message=sample_message)
+
+            mock_call_llm.assert_called_once()
+            _, kwargs = mock_call_llm.call_args
+            assert kwargs.get("temperature") == 0.8
+
+    async def test_generate_uses_correct_max_tokens(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+        valid_llm_response: LLMResponse,
+    ) -> None:
+        """max_tokens=300でLLMを呼び出すこと"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.return_value = valid_llm_response
+
+            await agent.generate_response(message=sample_message)
+
+            mock_call_llm.assert_called_once()
+            _, kwargs = mock_call_llm.call_args
+            assert kwargs.get("max_tokens") == 300
+
+
+class TestErrorHandling:
+    """エラーハンドリングのテスト"""
+
+    @pytest.fixture
+    def agent(self, litellm_settings: LiteLLMSettings) -> ResponseGeneratorAgent:
+        """テスト用ResponseGeneratorAgent"""
+        return ResponseGeneratorAgent(settings=litellm_settings)
+
+    async def test_llm_error_is_raised(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """LLMAPIErrorがそのままスローされること"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.side_effect = LLMAPIError(
+                message="API Error",
+                model="gpt-4o-mini",
+                status_code=500,
+            )
+
+            with pytest.raises(LLMAPIError) as exc_info:
+                await agent.generate_response(message=sample_message)
+
+            assert exc_info.value.status_code == 500
+
+    async def test_no_fallback_on_error(
+        self,
+        agent: ResponseGeneratorAgent,
+        sample_message: SlackMessage,
+    ) -> None:
+        """エラー時にフォールバック応答を返さないこと（例外がスローされること）"""
+        with patch.object(agent._agent, "call_llm", new_callable=AsyncMock) as mock_call_llm:
+            mock_call_llm.side_effect = LLMAPIError(
+                message="API Error",
+                model="gpt-4o-mini",
+                status_code=429,
+            )
+
+            # フォールバック応答ではなく、例外がスローされることを確認
+            with pytest.raises(LLMAPIError):
+                await agent.generate_response(message=sample_message)


### PR DESCRIPTION
## Summary

- ResponseGeneratorAgentクラスを実装
- Slackメッセージに対して友達のように自然な返信を生成するエージェント
- temperature=0.8（多様性重視）、max_tokens=300でLLM呼び出し
- エラー時はLLMAPIErrorをスロー（フォールバックなし）

## Test plan

- [x] 初期化テスト（LiteLLMSettings、カスタムペルソナ）
- [x] 応答生成テスト（コンテキストあり/なし）
- [x] パラメータテスト（temperature=0.8, max_tokens=300）
- [x] エラーハンドリングテスト（LLMAPIErrorがスローされること）
- [x] 全153テストがパス
- [x] ruff check, ruff format, ty check がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)