### PR TITLE
refactor: SlackSettingsからchannel_idsを削除

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -2,10 +2,9 @@
 # このファイルをconfig.yamlとしてコピーして使用してください
 
 # Slack設定
-slack:
-  channel_ids:  # 監視対象チャンネルIDのリスト
-    - "C123456"
-    - "C789012"
+# Note: Appがinviteされたチャンネルを自動的に監視します。
+#       明示的なチャンネルID設定は不要です。
+slack: {}
 
 # LLM設定（strands-agents LiteLLMModel形式）
 litellm:

--- a/nyao/config/settings.py
+++ b/nyao/config/settings.py
@@ -5,12 +5,11 @@
 
 import os
 import random
-import re
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,18 +21,13 @@ class ResponseDelaySettings(BaseModel):
 
 
 class SlackSettings(BaseModel):
-    """Slack設定"""
+    """Slack設定
 
-    channel_ids: list[str] = Field(description="監視対象チャンネルIDのリスト")
+    Note: Phase 1ではAppがinviteされたチャンネルを自動的に監視するため、
+    チャンネルIDの明示的な設定は不要です。将来的な拡張のために設定クラスを保持しています。
+    """
 
-    @field_validator("channel_ids")
-    @classmethod
-    def validate_channel_ids(cls, v: list[str]) -> list[str]:
-        """チャンネルIDのフォーマットを検証"""
-        for channel_id in v:
-            if not re.match(r"^C[A-Z0-9]+$", channel_id):
-                raise ValueError(f"Invalid channel ID format: {channel_id}")
-        return v
+    pass
 
 
 class BotSettings(BaseModel):
@@ -82,7 +76,7 @@ class Settings(BaseSettings):
     config: str = Field(default="config.yaml", description="設定ファイルのパス")
 
     # YAMLファイルから読み込む設定
-    slack: SlackSettings
+    slack: SlackSettings = Field(default_factory=SlackSettings)
     litellm: LiteLLMSettings
     bot: BotSettings = Field(default_factory=BotSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,6 @@ from nyao.config.settings import (
     BotSettings,
     LiteLLMSettings,
     LoggingSettings,
-    SlackSettings,
     get_response_delay_with_jitter,
     get_settings,
     reload_settings,
@@ -27,7 +26,6 @@ class TestSettings:
         # 最小限の設定ファイルを作成
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456"]},
             "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
@@ -49,7 +47,6 @@ class TestSettings:
 
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456", "C789012"]},
             "litellm": {
                 "model_id": "openai/gpt-4o",
                 "params": {"temperature": 0.8, "max_tokens": 2000},
@@ -65,7 +62,6 @@ class TestSettings:
         reload_settings()
         settings = get_settings()
 
-        assert settings.slack.channel_ids == ["C123456", "C789012"]
         assert settings.litellm.model_id == "openai/gpt-4o"
         assert settings.litellm.params["temperature"] == 0.8
         assert settings.litellm.params["max_tokens"] == 2000
@@ -82,7 +78,6 @@ class TestSettings:
 
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456"]},
             "litellm": {
                 "model_id": "openai/gpt-4o",
                 "client_args": {"api_key": "$OPENAI_API_KEY"},
@@ -106,7 +101,6 @@ class TestSettings:
         # 最小限の設定ファイル（デフォルト値を使用）
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456"]},
             "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
@@ -130,7 +124,6 @@ class TestSettings:
 
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456"]},
             "litellm": {"model_id": "openai/gpt-4o"},
         }
         with open(config_file, "w") as f:
@@ -148,7 +141,6 @@ class TestSettings:
 
         config_file = tmp_path / "config.yaml"
         config_data = {
-            "slack": {"channel_ids": ["C123456"]},
             "litellm": {"model_id": "openai/gpt-4o"},
             "bot": {"response_delay": {"base": 60, "jitter": 10}},
         }
@@ -163,20 +155,6 @@ class TestSettings:
         for _ in range(10):
             delay = get_response_delay_with_jitter()
             assert 50 <= delay <= 70  # base(60) - jitter(10) から base(60) + jitter(10)
-
-
-class TestSlackSettings:
-    """Slack設定のテスト"""
-
-    def test_valid_channel_ids(self):
-        """正しいチャンネルIDが受け入れられること"""
-        settings = SlackSettings(channel_ids=["C123456", "C789012"])
-        assert len(settings.channel_ids) == 2
-
-    def test_invalid_channel_ids_raises_error(self):
-        """不正なチャンネルIDが拒否されること"""
-        with pytest.raises(ValidationError):
-            SlackSettings(channel_ids=["invalid-id"])
 
 
 class TestBotSettings:


### PR DESCRIPTION
## Summary

PR #18 のドキュメント変更に基づき、設定からchannel_idsを削除しました。

- SlackSettingsクラスからchannel_idsフィールドを削除
- config.yaml.exampleからchannel_ids設定を削除
- 関連テストを更新

Appがinviteされたチャンネルを自動的に監視する方式に変更。

## Test plan
- [x] すべてのテストがパス（151件）
- [x] ruffによるコード品質チェックがパス
- [x] tyによる型チェックがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)