### PR TITLE
feat: ResponseDelayControllerの実装

### DIFF
--- a/nyao/services/delay_controller.py
+++ b/nyao/services/delay_controller.py
@@ -1,0 +1,162 @@
+"""反応待機制御
+
+メッセージ受信後、設定された時間だけ待機してから応答判定を行います。
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from nyao.core.logging import get_logger
+from nyao.core.models import SlackMessage
+
+logger = get_logger(__name__)
+
+
+class ResponseDelayController:
+    """反応待機制御
+
+    メッセージ受信後、設定された時間だけ待機してから応答判定を行います。
+    待機中に他のユーザーからの反応があった場合、待機をキャンセルします。
+    """
+
+    DEFAULT_DELAY_SECONDS = 60
+
+    def __init__(self, delay_seconds: int = DEFAULT_DELAY_SECONDS) -> None:
+        """初期化
+
+        Args:
+            delay_seconds: 応答判定までの待機時間（秒）
+        """
+        self._delay_seconds = delay_seconds
+        self._pending_tasks: dict[str, asyncio.Task[None]] = {}
+
+        logger.info(
+            "response_delay_controller_initialized",
+            delay_seconds=delay_seconds,
+        )
+
+    @property
+    def delay_seconds(self) -> int:
+        """待機時間を取得"""
+        return self._delay_seconds
+
+    def schedule_response_check(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+    ) -> None:
+        """応答チェックをスケジュール
+
+        既存のタスクがあればキャンセルし、新しい非同期タスクを作成します。
+
+        Args:
+            message: 対象のSlackメッセージ
+            callback: 遅延後に実行するコールバック関数
+        """
+        task_key = self._make_task_key(message)
+
+        # 既存のタスクがあればキャンセル
+        if task_key in self._pending_tasks:
+            existing_task = self._pending_tasks[task_key]
+            existing_task.cancel()
+            logger.debug(
+                "existing_task_cancelled",
+                task_key=task_key,
+            )
+
+        # 新しいタスクを作成
+        task = asyncio.create_task(self._delayed_callback(message, callback, task_key))
+        self._pending_tasks[task_key] = task
+
+        logger.debug(
+            "response_check_scheduled",
+            task_key=task_key,
+            delay_seconds=self._delay_seconds,
+        )
+
+    def cancel_response_check(self, message: SlackMessage) -> bool:
+        """応答チェックをキャンセル
+
+        Args:
+            message: キャンセル対象のメッセージ
+
+        Returns:
+            キャンセルに成功した場合はTrue、タスクが存在しない場合はFalse
+        """
+        task_key = self._make_task_key(message)
+
+        if task_key not in self._pending_tasks:
+            logger.debug(
+                "cancel_task_not_found",
+                task_key=task_key,
+            )
+            return False
+
+        task = self._pending_tasks.pop(task_key)
+        task.cancel()
+
+        logger.debug(
+            "response_check_cancelled",
+            task_key=task_key,
+        )
+        return True
+
+    async def _delayed_callback(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+        task_key: str,
+    ) -> None:
+        """遅延コールバック
+
+        指定時間待機後にコールバックを実行します。
+        キャンセルされた場合はCancelledErrorをハンドリングします。
+
+        Args:
+            message: 対象のSlackメッセージ
+            callback: 実行するコールバック関数
+            task_key: タスクのキー（クリーンアップ用）
+        """
+        try:
+            await asyncio.sleep(self._delay_seconds)
+
+            logger.debug(
+                "executing_delayed_callback",
+                task_key=task_key,
+            )
+
+            await callback(message)
+
+            logger.info(
+                "delayed_callback_completed",
+                task_key=task_key,
+            )
+        except asyncio.CancelledError:
+            logger.debug(
+                "delayed_callback_cancelled",
+                task_key=task_key,
+            )
+            raise
+        finally:
+            # タスクを削除
+            self._pending_tasks.pop(task_key, None)
+
+    def _make_task_key(self, message: SlackMessage) -> str:
+        """タスクキーを生成
+
+        Args:
+            message: 対象のSlackメッセージ
+
+        Returns:
+            "channel_id:message_id" 形式のキー
+        """
+        return f"{message.channel_id}:{message.message_id}"
+
+    def get_pending_count(self) -> int:
+        """待機中のタスク数を取得
+
+        Returns:
+            待機中のタスク数
+        """
+        return len(self._pending_tasks)

--- a/tests/services/test_delay_controller.py
+++ b/tests/services/test_delay_controller.py
@@ -1,0 +1,299 @@
+"""反応待機制御のテスト"""
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nyao.core.models import SlackMessage
+from nyao.services.delay_controller import ResponseDelayController
+
+
+@pytest.fixture
+def controller() -> ResponseDelayController:
+    """テスト用コントローラ（デフォルト設定）"""
+    return ResponseDelayController()
+
+
+@pytest.fixture
+def controller_short_delay() -> ResponseDelayController:
+    """短い遅延のコントローラ（テスト用）"""
+    return ResponseDelayController(delay_seconds=1)
+
+
+@pytest.fixture
+def sample_message() -> SlackMessage:
+    """テスト用SlackMessage"""
+    return SlackMessage(
+        message_id="msg-001",
+        channel_id="C12345678",
+        user_id="U12345678",
+        user_name="testuser",
+        text="テストメッセージ",
+        timestamp=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def another_message() -> SlackMessage:
+    """別のテスト用SlackMessage"""
+    return SlackMessage(
+        message_id="msg-002",
+        channel_id="C12345678",
+        user_id="U12345678",
+        user_name="testuser",
+        text="別のメッセージ",
+        timestamp=datetime.now(UTC),
+    )
+
+
+class TestResponseDelayControllerInit:
+    """初期化テスト"""
+
+    def test_init_with_default_values(self) -> None:
+        """デフォルト値で初期化できること"""
+        controller = ResponseDelayController()
+        assert controller is not None
+        assert controller.delay_seconds == 60
+
+    def test_init_with_custom_delay(self) -> None:
+        """カスタムdelay_secondsで初期化できること"""
+        controller = ResponseDelayController(delay_seconds=120)
+        assert controller.delay_seconds == 120
+
+    def test_init_pending_tasks_empty(self) -> None:
+        """初期状態で待機中タスクが空であること"""
+        controller = ResponseDelayController()
+        assert controller.get_pending_count() == 0
+
+
+class TestMakeTaskKey:
+    """タスクキー生成テスト"""
+
+    def test_make_task_key(self, controller: ResponseDelayController) -> None:
+        """タスクキーが正しく生成されること"""
+        message = SlackMessage(
+            message_id="msg-001",
+            channel_id="C12345678",
+            user_id="U12345678",
+            user_name="testuser",
+            text="テスト",
+            timestamp=datetime.now(UTC),
+        )
+        key = controller._make_task_key(message)
+        assert key == "C12345678:msg-001"
+
+    def test_make_task_key_different_channel(self, controller: ResponseDelayController) -> None:
+        """異なるチャンネルで異なるキーが生成されること"""
+        message1 = SlackMessage(
+            message_id="msg-001",
+            channel_id="C11111111",
+            user_id="U12345678",
+            user_name="testuser",
+            text="テスト",
+            timestamp=datetime.now(UTC),
+        )
+        message2 = SlackMessage(
+            message_id="msg-001",
+            channel_id="C22222222",
+            user_id="U12345678",
+            user_name="testuser",
+            text="テスト",
+            timestamp=datetime.now(UTC),
+        )
+        key1 = controller._make_task_key(message1)
+        key2 = controller._make_task_key(message2)
+        assert key1 != key2
+        assert key1 == "C11111111:msg-001"
+        assert key2 == "C22222222:msg-001"
+
+
+class TestScheduleResponseCheck:
+    """スケジューリングテスト"""
+
+    async def test_schedule_creates_task(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """スケジュールでタスクが作成されること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+
+        assert controller_short_delay.get_pending_count() == 1
+
+        # クリーンアップ
+        controller_short_delay.cancel_response_check(sample_message)
+
+    async def test_schedule_replaces_existing_task(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """既存タスクがある場合に置き換えられること"""
+        callback1 = AsyncMock()
+        callback2 = AsyncMock()
+
+        controller_short_delay.schedule_response_check(sample_message, callback1)
+        controller_short_delay.schedule_response_check(sample_message, callback2)
+
+        # タスク数は1のまま
+        assert controller_short_delay.get_pending_count() == 1
+
+        # クリーンアップ
+        controller_short_delay.cancel_response_check(sample_message)
+
+    async def test_schedule_multiple_messages(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+        another_message: SlackMessage,
+    ) -> None:
+        """複数メッセージのスケジュールが独立して管理されること"""
+        callback1 = AsyncMock()
+        callback2 = AsyncMock()
+
+        controller_short_delay.schedule_response_check(sample_message, callback1)
+        controller_short_delay.schedule_response_check(another_message, callback2)
+
+        assert controller_short_delay.get_pending_count() == 2
+
+        # クリーンアップ
+        controller_short_delay.cancel_response_check(sample_message)
+        controller_short_delay.cancel_response_check(another_message)
+
+
+class TestCancelResponseCheck:
+    """キャンセルテスト"""
+
+    async def test_cancel_existing_task(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """既存タスクがキャンセルできること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+
+        result = controller_short_delay.cancel_response_check(sample_message)
+
+        assert result is True
+        # 少し待ってタスクのクリーンアップを確認
+        await asyncio.sleep(0.1)
+        assert controller_short_delay.get_pending_count() == 0
+
+    async def test_cancel_nonexistent_task(
+        self,
+        controller: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """存在しないタスクのキャンセルはFalseを返すこと"""
+        result = controller.cancel_response_check(sample_message)
+        assert result is False
+
+    async def test_cancel_prevents_callback(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """キャンセルによりコールバックが実行されないこと"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+        controller_short_delay.cancel_response_check(sample_message)
+
+        # 遅延時間を超えて待機
+        await asyncio.sleep(1.5)
+
+        callback.assert_not_called()
+
+
+class TestDelayedCallback:
+    """遅延コールバックテスト"""
+
+    async def test_callback_executed_after_delay(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """遅延後にコールバックが実行されること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+
+        # コールバックがまだ実行されていないこと
+        await asyncio.sleep(0.5)
+        callback.assert_not_called()
+
+        # 遅延後にコールバックが実行されること
+        await asyncio.sleep(1.0)
+        callback.assert_called_once_with(sample_message)
+
+    async def test_callback_receives_correct_message(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """コールバックに正しいメッセージが渡されること"""
+        received_message = None
+
+        async def capture_callback(msg: SlackMessage) -> None:
+            nonlocal received_message
+            received_message = msg
+
+        controller_short_delay.schedule_response_check(sample_message, capture_callback)
+
+        await asyncio.sleep(1.5)
+
+        assert received_message is not None
+        assert received_message.message_id == sample_message.message_id
+        assert received_message.channel_id == sample_message.channel_id
+
+    async def test_task_removed_after_completion(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """コールバック完了後にタスクが削除されること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+
+        assert controller_short_delay.get_pending_count() == 1
+
+        await asyncio.sleep(1.5)
+
+        assert controller_short_delay.get_pending_count() == 0
+
+
+class TestGetPendingCount:
+    """待機中タスク数テスト"""
+
+    def test_pending_count_initial(self, controller: ResponseDelayController) -> None:
+        """初期状態で0であること"""
+        assert controller.get_pending_count() == 0
+
+    async def test_pending_count_after_schedule(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """スケジュール後にカウントが増加すること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+
+        assert controller_short_delay.get_pending_count() == 1
+
+        # クリーンアップ
+        controller_short_delay.cancel_response_check(sample_message)
+
+    async def test_pending_count_after_cancel(
+        self,
+        controller_short_delay: ResponseDelayController,
+        sample_message: SlackMessage,
+    ) -> None:
+        """キャンセル後にカウントが減少すること"""
+        callback = AsyncMock()
+        controller_short_delay.schedule_response_check(sample_message, callback)
+        controller_short_delay.cancel_response_check(sample_message)
+
+        await asyncio.sleep(0.1)
+        assert controller_short_delay.get_pending_count() == 0


### PR DESCRIPTION
## Summary

- メッセージ受信後、設定された時間だけ待機してから応答判定を行う非同期制御コンポーネントを実装
- asyncio.Taskを使用した遅延コールバック実行機能
- 既存タスクのキャンセル機能と待機中タスクの管理

## Test plan

- [ ] `uv run pytest tests/services/test_delay_controller.py -v` で17件のテストがパスすること
- [ ] `uv run ruff check .` でlintエラーがないこと
- [ ] `uv run ty check .` で型エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)