### PR TITLE
docs: Add Phase 2 implementation plan and detailed design documents

### DIFF
--- a/specs/phase-2/01-litellm-migration.md
+++ b/specs/phase-2/01-litellm-migration.md
@@ -1,0 +1,539 @@
+# LiteLLM直接使用への移行
+
+## 概要
+
+Phase 2.1では、strands-agentsを削除し、LiteLLMの`acompletion`を直接使用するエージェント基盤を実装します。これにより、依存関係を簡素化し、将来のtool call対応（Phase 3）に向けた基盤を整えます。
+
+## 実装優先度
+
+**最優先** - Phase 2のすべての機能がこの移行を前提としています。
+
+## 依存関係
+
+### 依存先
+- Phase 1の基盤レイヤー（設定管理、ロギング、エラーハンドリング）
+- LiteLLM パッケージ
+
+### 依存元
+- スマート応答判定（Phase 2.2-2.3）
+- 階層的記憶管理（Phase 2.4）
+
+---
+
+## コンポーネント
+
+### 1. NyaoAgentクラス（リファクタリング）
+
+#### 目的
+
+strands-agentsへの依存を削除し、LiteLLMを直接使用するエージェント基盤を提供します。
+
+#### 機能要件
+
+- LiteLLM `acompletion` を使用した非同期LLM呼び出し
+- 構造化出力（JSON）のパース機能
+- エラーハンドリングとリトライ機能
+- 設定に基づくモデル・パラメータ管理
+
+#### 実装方針
+
+**変更前（strands-agents使用）**:
+```python
+from strands import Agent
+
+class NyaoAgent:
+    def __init__(self, settings: LiteLLMSettings, ...):
+        self._agent = Agent(
+            model=settings.model_id,
+            ...
+        )
+
+    async def call_llm(self, prompt: str) -> LLMResponse:
+        result = await self._agent(prompt)
+        return LLMResponse(content=result.message, ...)
+```
+
+**変更後（LiteLLM直接使用）**:
+```python
+import litellm
+
+class NyaoAgent:
+    def __init__(self, settings: LiteLLMSettings, ...):
+        self._model = settings.model_id
+        self._client_args = settings.client_args
+        self._params = settings.params
+
+    async def call_llm(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        response = await litellm.acompletion(
+            model=self._model,
+            messages=messages,
+            temperature=temperature or self._params.temperature,
+            max_tokens=max_tokens or self._params.max_tokens,
+            **self._client_args,
+        )
+        return self._parse_response(response)
+```
+
+#### 主要インターフェース
+
+```python
+class NyaoAgent:
+    """LiteLLMを直接使用するエージェント基盤"""
+
+    MAX_RETRIES: int = 3
+    RETRY_DELAY: float = 1.0
+    RETRY_BACKOFF: float = 2.0
+
+    def __init__(
+        self,
+        settings: LiteLLMSettings,
+        system_prompt: str | None = None,
+        skip_retry: bool = False,
+    ) -> None:
+        """
+        エージェントを初期化する。
+
+        Args:
+            settings: LiteLLM設定
+            system_prompt: システムプロンプト（オプション）
+            skip_retry: リトライをスキップするか（テスト用）
+        """
+
+    async def call_llm(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        """
+        LiteLLM acompletion を呼び出す。
+
+        Args:
+            messages: メッセージリスト（role, content）
+            temperature: 生成温度（オプション、設定値を上書き）
+            max_tokens: 最大トークン数（オプション、設定値を上書き）
+
+        Returns:
+            LLMResponse: LLMからの応答
+
+        Raises:
+            LLMAPIError: API呼び出しに失敗した場合
+        """
+
+    async def call_llm_with_structured_output(
+        self,
+        messages: list[dict[str, str]],
+        output_model: type[T],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> T:
+        """
+        JSON出力を要求し、Pydanticモデルにパースする。
+
+        Args:
+            messages: メッセージリスト
+            output_model: 出力のPydanticモデル型
+            temperature: 生成温度（オプション）
+            max_tokens: 最大トークン数（オプション）
+
+        Returns:
+            T: パースされたPydanticモデルインスタンス
+
+        Raises:
+            LLMAPIError: API呼び出しに失敗した場合
+            ValidationError: JSONパースに失敗した場合
+        """
+
+    def _build_messages(
+        self,
+        messages: list[dict[str, str]],
+    ) -> list[dict[str, str]]:
+        """
+        システムプロンプトを含むメッセージリストを構築する。
+        """
+
+    def _parse_response(self, response: Any) -> LLMResponse:
+        """
+        LiteLLMのレスポンスをLLMResponseに変換する。
+        """
+
+    async def _call_with_retry(
+        self,
+        func: Callable[[], Awaitable[T]],
+    ) -> T:
+        """
+        リトライ付きで関数を実行する。
+        """
+```
+
+#### テスト要件
+
+- [ ] `call_llm()` が正常に動作すること
+- [ ] `call_llm_with_structured_output()` がJSONをパースできること
+- [ ] システムプロンプトが正しく付与されること
+- [ ] リトライが設定回数実行されること
+- [ ] タイムアウト時に適切なエラーが発生すること
+- [ ] `skip_retry=True` でリトライがスキップされること
+
+---
+
+### 2. ResponseJudgeAgent（更新）
+
+#### 目的
+
+応答判定をLiteLLM直接使用に移行し、構造化出力機能を活用します。
+
+#### 機能要件
+
+- FR-001: 応答判定（継続）
+- FR-602: 返信先判定（新規、Phase 2.3で実装）
+
+#### 実装方針
+
+**変更前**:
+```python
+class ResponseJudgeAgent(NyaoAgent):
+    async def judge(self, context: str) -> ResponseDecision:
+        prompt = self._build_prompt(context)
+        response = await self.call_llm(prompt)
+        return self._parse_decision(response.content)
+```
+
+**変更後**:
+```python
+class ResponseJudgeAgent(NyaoAgent):
+    async def judge(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> ResponseDecision:
+        messages = self._build_messages_for_judgment(context, message)
+        return await self.call_llm_with_structured_output(
+            messages=messages,
+            output_model=ResponseDecision,
+        )
+```
+
+#### 主要インターフェース
+
+```python
+class ResponseJudgeAgent(NyaoAgent):
+    """応答判定エージェント"""
+
+    def __init__(
+        self,
+        settings: LiteLLMSettings,
+        persona: str | None = None,
+        skip_retry: bool = False,
+    ) -> None:
+        """
+        応答判定エージェントを初期化する。
+
+        Args:
+            settings: LiteLLM設定
+            persona: ボットのペルソナ（オプション）
+            skip_retry: リトライをスキップするか
+        """
+
+    async def judge(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> ResponseDecision:
+        """
+        メッセージに対して応答すべきかを判定する。
+
+        Args:
+            context: 会話コンテキスト
+            message: 判定対象のメッセージ
+
+        Returns:
+            ResponseDecision: 判定結果
+        """
+
+    def _build_messages_for_judgment(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> list[dict[str, str]]:
+        """
+        応答判定用のメッセージリストを構築する。
+        """
+```
+
+#### テスト要件
+
+- [ ] 応答判定が正しく動作すること
+- [ ] ResponseDecisionが正しくパースされること
+- [ ] コンテキストが正しく渡されること
+- [ ] ペルソナが反映されること
+
+---
+
+### 3. ResponseGeneratorAgent（更新）
+
+#### 目的
+
+応答生成をLiteLLM直接使用に移行します。
+
+#### 機能要件
+
+- FR-002: 応答生成（継続）
+
+#### 実装方針
+
+**変更後**:
+```python
+class ResponseGeneratorAgent(NyaoAgent):
+    async def generate(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> str:
+        messages = self._build_messages_for_generation(context, message)
+        response = await self.call_llm(messages=messages)
+        return self._postprocess(response.content)
+```
+
+#### 主要インターフェース
+
+```python
+class ResponseGeneratorAgent(NyaoAgent):
+    """応答生成エージェント"""
+
+    def __init__(
+        self,
+        settings: LiteLLMSettings,
+        persona: str | None = None,
+        skip_retry: bool = False,
+    ) -> None:
+        """
+        応答生成エージェントを初期化する。
+
+        Args:
+            settings: LiteLLM設定
+            persona: ボットのペルソナ（オプション）
+            skip_retry: リトライをスキップするか
+        """
+
+    async def generate(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> str:
+        """
+        メッセージに対する応答を生成する。
+
+        Args:
+            context: 会話コンテキスト
+            message: 応答対象のメッセージ
+
+        Returns:
+            str: 生成された応答テキスト
+        """
+
+    def _build_messages_for_generation(
+        self,
+        context: ConversationContext,
+        message: SlackMessage,
+    ) -> list[dict[str, str]]:
+        """
+        応答生成用のメッセージリストを構築する。
+        """
+
+    def _postprocess(self, content: str) -> str:
+        """
+        生成された応答を後処理する。
+        - 前後の空白を削除
+        - 不要な引用符を削除
+        """
+```
+
+#### テスト要件
+
+- [ ] 応答生成が正しく動作すること
+- [ ] コンテキストが正しく渡されること
+- [ ] 後処理が正しく適用されること
+- [ ] ペルソナが反映されること
+
+---
+
+### 4. PromptManager（更新）
+
+#### 目的
+
+プロンプトテンプレートを管理し、メッセージリスト形式での出力に対応します。
+
+#### 実装方針
+
+Phase 1のPromptManagerを拡張し、JSON出力形式の指示を含むプロンプトを生成します。
+
+#### 主要インターフェース
+
+```python
+class PromptManager:
+    """プロンプト管理"""
+
+    DEFAULT_PERSONA: str = "..."
+
+    @staticmethod
+    def build_judgment_messages(
+        context: ConversationContext,
+        message: SlackMessage,
+        persona: str | None = None,
+    ) -> list[dict[str, str]]:
+        """
+        応答判定用のメッセージリストを構築する。
+
+        Returns:
+            list[dict[str, str]]: システムプロンプトとユーザーメッセージのリスト
+        """
+
+    @staticmethod
+    def build_generation_messages(
+        context: ConversationContext,
+        message: SlackMessage,
+        persona: str | None = None,
+    ) -> list[dict[str, str]]:
+        """
+        応答生成用のメッセージリストを構築する。
+        """
+
+    @staticmethod
+    def get_json_output_instruction(model: type[BaseModel]) -> str:
+        """
+        JSON出力形式の指示文を生成する。
+
+        Args:
+            model: 出力のPydanticモデル型
+
+        Returns:
+            str: JSON出力形式の指示文
+        """
+```
+
+#### テスト要件
+
+- [ ] メッセージリストが正しく構築されること
+- [ ] JSON出力指示が正しく生成されること
+- [ ] ペルソナが正しく反映されること
+
+---
+
+## ディレクトリ構成
+
+```
+nyao/
+├── integrations/
+│   └── llm/
+│       ├── __init__.py
+│       ├── agent_base.py      # NyaoAgent（リファクタリング）
+│       ├── judge_agent.py     # ResponseJudgeAgent（更新）
+│       ├── generator_agent.py # ResponseGeneratorAgent（更新）
+│       └── prompts.py         # PromptManager（更新）
+```
+
+---
+
+## 実装タスク
+
+### Day 1-2: NyaoAgentクラスのリファクタリング
+
+- [ ] `litellm` パッケージを直接依存として追加
+- [ ] `NyaoAgent.__init__()` からstrands.Agent依存を削除
+- [ ] `NyaoAgent.call_llm()` をメッセージリスト形式に変更
+- [ ] `NyaoAgent.call_llm_with_structured_output()` を実装
+- [ ] `NyaoAgent._call_with_retry()` を実装
+- [ ] テストを作成・実行
+
+### Day 3: ResponseJudgeAgentの更新
+
+- [ ] `judge()` メソッドを更新
+- [ ] `_build_messages_for_judgment()` を実装
+- [ ] テストを更新・実行
+
+### Day 4: ResponseGeneratorAgentの更新
+
+- [ ] `generate()` メソッドを更新
+- [ ] `_build_messages_for_generation()` を実装
+- [ ] テストを更新・実行
+
+### Day 5: strands-agents依存の削除
+
+- [ ] `pyproject.toml` から `strands-agents` を削除
+- [ ] 全ファイルからstrands関連のインポートを削除
+- [ ] 全テストを実行
+- [ ] ruff、tyによるチェック
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+```python
+# tests/integrations/llm/test_agent_base.py
+
+@pytest.mark.asyncio
+async def test_call_llm_returns_response():
+    """call_llmが正しくLLMResponseを返すこと"""
+
+@pytest.mark.asyncio
+async def test_call_llm_with_structured_output_parses_json():
+    """call_llm_with_structured_outputがJSONをパースすること"""
+
+@pytest.mark.asyncio
+async def test_retry_on_error():
+    """エラー時にリトライが実行されること"""
+
+@pytest.mark.asyncio
+async def test_skip_retry():
+    """skip_retry=Trueでリトライがスキップされること"""
+```
+
+### モック戦略
+
+```python
+@pytest.fixture
+def mock_litellm_acompletion(mocker):
+    """litellm.acompletionのモック"""
+    return mocker.patch(
+        "litellm.acompletion",
+        return_value=AsyncMock(return_value=mock_response),
+    )
+```
+
+---
+
+## 依存パッケージ
+
+### 追加
+
+```toml
+[project.dependencies]
+litellm = ">=1.0.0"
+```
+
+### 削除
+
+```toml
+# 削除対象
+strands-agents = "..."
+```
+
+---
+
+## 完了条件
+
+- [ ] NyaoAgentがLiteLLMを直接使用していること
+- [ ] call_llm_with_structured_outputが実装されていること
+- [ ] ResponseJudgeAgentが更新されていること
+- [ ] ResponseGeneratorAgentが更新されていること
+- [ ] strands-agentsへの依存がないこと
+- [ ] 全テストがパスすること
+- [ ] ruff、tyによるチェックがパスすること

--- a/specs/phase-2/02-smart-response.md
+++ b/specs/phase-2/02-smart-response.md
@@ -1,0 +1,565 @@
+# スマート応答判定
+
+## 概要
+
+Phase 2.2-2.3では、スマート応答判定機能を実装します。これには、リクエストごとのjitter適用、再判定機能、返信先判定が含まれます。
+
+## 実装優先度
+
+**高** - LiteLLM移行（Phase 2.1）完了後に実装
+
+## 依存関係
+
+### 依存先
+- Phase 2.1: LiteLLM直接使用への移行
+- Phase 1: ResponseDelayController
+
+### 依存元
+- Phase 2.4: 階層的記憶管理（MemoryContextBuilder）
+
+---
+
+## コンポーネント
+
+### 1. ResponseDelayController（拡張）- jitter毎回計算
+
+#### 目的
+
+リクエストごとにjitterを適用し、応答タイミングをより自然にします。
+
+#### 機能要件
+
+- **FR-603**: レスポンス遅延時間をリクエストごとにjitter適用
+
+#### 現状の問題
+
+現在の実装では、jitterがNyaoBotの初期化時に一度だけ計算され、すべてのリクエストで同じ遅延時間が使用されています。
+
+```python
+# 現在の実装（main.py）
+class NyaoBot:
+    def __init__(self, ...):
+        self._delay_seconds = settings.get_response_delay_with_jitter()
+        self._delay_controller = ResponseDelayController(
+            delay_seconds=self._delay_seconds,
+            ...
+        )
+```
+
+#### 実装方針
+
+`schedule_response_check()` 呼び出し時に毎回jitterを計算するように変更します。
+
+**変更後**:
+```python
+class ResponseDelayController:
+    def __init__(
+        self,
+        settings: BotSettings,
+        ...
+    ) -> None:
+        self._settings = settings
+        # delay_secondsを固定値ではなく、毎回計算
+
+    def schedule_response_check(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+    ) -> None:
+        delay = self._settings.get_response_delay_with_jitter()
+        # delayを使用してスケジュール
+```
+
+#### 主要インターフェース
+
+```python
+class ResponseDelayController:
+    """応答遅延制御"""
+
+    def __init__(
+        self,
+        settings: BotSettings,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        """
+        遅延制御を初期化する。
+
+        Args:
+            settings: ボット設定（response_delay設定を含む）
+            loop: イベントループ（オプション）
+        """
+
+    def schedule_response_check(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+    ) -> None:
+        """
+        応答チェックをスケジュールする。
+        毎回jitterを適用した遅延時間を計算する。
+
+        Args:
+            message: 対象メッセージ
+            callback: 遅延後に実行するコールバック
+        """
+
+    def cancel(self, message: SlackMessage) -> bool:
+        """
+        スケジュールされた応答チェックをキャンセルする。
+
+        Args:
+            message: 対象メッセージ
+
+        Returns:
+            bool: キャンセルに成功した場合True
+        """
+
+    def cancel_all(self) -> int:
+        """
+        すべてのスケジュールされた応答チェックをキャンセルする。
+
+        Returns:
+            int: キャンセルされたタスク数
+        """
+```
+
+#### テスト要件
+
+- [ ] リクエストごとに異なる遅延時間が適用されること
+- [ ] jitterの範囲が設定値内であること
+- [ ] 既存のスケジュール・キャンセル機能が動作すること
+
+---
+
+### 2. RejudgeTracker（新規）- 再判定機能
+
+#### 目的
+
+「返答不要」と判定されたメッセージに対して、一定時間経過後に再判定を行います。
+
+#### 機能要件
+
+- **FR-601**: 返答しないと判定したメッセージに対して、一定時間経過後に再判定
+  - 条件: 固定時間経過 + 新しいメッセージがない場合
+  - 最大再判定回数を設定可能
+
+#### 実装方針
+
+新しい`RejudgeTracker`クラスを実装し、再判定のスケジューリングと追跡を行います。
+
+```python
+class RejudgeTracker:
+    """再判定の追跡と管理"""
+
+    def __init__(
+        self,
+        settings: RejudgeSettings,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        self._settings = settings
+        self._loop = loop or asyncio.get_event_loop()
+        self._pending_rejudges: dict[str, RejudgeInfo] = {}
+        self._rejudge_counts: dict[str, int] = {}
+
+    def schedule_rejudge(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+    ) -> None:
+        """再判定をスケジュール"""
+        key = self._get_message_key(message)
+        if self._rejudge_counts.get(key, 0) >= self._settings.max_count:
+            return  # 最大回数に達している
+
+        task = self._loop.call_later(
+            self._settings.interval_seconds,
+            lambda: asyncio.create_task(callback(message)),
+        )
+        self._pending_rejudges[key] = RejudgeInfo(task=task, message=message)
+```
+
+#### 設定
+
+```python
+# config/settings.py に追加
+
+class RejudgeSettings(BaseModel):
+    """再判定設定"""
+
+    interval_seconds: int = Field(
+        default=300,
+        ge=60,
+        le=3600,
+        description="再判定までの待機時間（秒）",
+    )
+    max_count: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="最大再判定回数",
+    )
+```
+
+#### 主要インターフェース
+
+```python
+@dataclass
+class RejudgeInfo:
+    """再判定情報"""
+    task: asyncio.TimerHandle
+    message: SlackMessage
+    scheduled_at: datetime
+
+
+class RejudgeTracker:
+    """再判定の追跡と管理"""
+
+    def __init__(
+        self,
+        settings: RejudgeSettings,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        """
+        再判定トラッカーを初期化する。
+
+        Args:
+            settings: 再判定設定
+            loop: イベントループ（オプション）
+        """
+
+    def should_rejudge(self, message: SlackMessage) -> bool:
+        """
+        再判定すべきか判定する。
+
+        Args:
+            message: 対象メッセージ
+
+        Returns:
+            bool: 再判定すべき場合True
+        """
+
+    def schedule_rejudge(
+        self,
+        message: SlackMessage,
+        callback: Callable[[SlackMessage], Awaitable[Any]],
+    ) -> bool:
+        """
+        再判定をスケジュールする。
+
+        Args:
+            message: 対象メッセージ
+            callback: 再判定時に実行するコールバック
+
+        Returns:
+            bool: スケジュールに成功した場合True（最大回数超過時はFalse）
+        """
+
+    def cancel_rejudge(self, channel_id: str, thread_ts: str | None = None) -> bool:
+        """
+        再判定をキャンセルする（新メッセージが来た場合）。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ（オプション）
+
+        Returns:
+            bool: キャンセルに成功した場合True
+        """
+
+    def increment_count(self, message: SlackMessage) -> int:
+        """
+        再判定回数をインクリメントする。
+
+        Args:
+            message: 対象メッセージ
+
+        Returns:
+            int: 更新後の再判定回数
+        """
+
+    def get_count(self, message: SlackMessage) -> int:
+        """
+        現在の再判定回数を取得する。
+
+        Args:
+            message: 対象メッセージ
+
+        Returns:
+            int: 再判定回数
+        """
+
+    def _get_message_key(self, message: SlackMessage) -> str:
+        """メッセージの一意キーを生成する"""
+```
+
+#### NyaoBotへの統合
+
+```python
+# main.py の更新
+
+class NyaoBot:
+    def __init__(self, ...):
+        self._rejudge_tracker = RejudgeTracker(
+            settings=settings.bot.rejudge,
+        )
+
+    async def _check_and_respond(self, message: SlackMessage) -> None:
+        decision = await self._response_judge.should_respond_to_message(
+            message=message,
+            context=context,
+        )
+
+        if decision.should_respond:
+            await self._send_response(message, context)
+        else:
+            # 応答しない場合、再判定をスケジュール
+            if self._rejudge_tracker.should_rejudge(message):
+                self._rejudge_tracker.schedule_rejudge(
+                    message=message,
+                    callback=self._check_and_respond,
+                )
+                self._rejudge_tracker.increment_count(message)
+
+    async def _handle_message(self, event: dict) -> None:
+        # 新メッセージ受信時、既存の再判定をキャンセル
+        channel_id = event.get("channel")
+        thread_ts = event.get("thread_ts")
+        self._rejudge_tracker.cancel_rejudge(channel_id, thread_ts)
+        # 通常のメッセージ処理...
+```
+
+#### テスト要件
+
+- [ ] 再判定がスケジュールされること
+- [ ] 新メッセージで再判定がキャンセルされること
+- [ ] 最大回数で再判定がスケジュールされないこと
+- [ ] 再判定回数が正しくカウントされること
+
+---
+
+### 3. ReplyTarget enumとResponseDecision拡張 - 返信先判定
+
+#### 目的
+
+応答先（スレッド/チャンネル直接投稿）を判定し、適切な場所に応答を送信します。
+
+#### 機能要件
+
+- **FR-602**: 返信先（スレッド/チャンネル）を判定
+  - 個人的な話題・既存スレッドの話題 → スレッドに返信
+  - みんなに見てもらいたい内容 → チャンネルに直接投稿
+
+#### 実装方針
+
+`ResponseDecision`モデルを拡張し、返信先を含めます。
+
+```python
+# core/models.py に追加
+
+class ReplyTarget(str, Enum):
+    """返信先"""
+    THREAD = "thread"    # スレッドに返信
+    CHANNEL = "channel"  # チャンネルに直接投稿
+
+
+class ResponseDecision(BaseModel):
+    """応答判定結果"""
+
+    should_respond: bool = Field(description="応答すべきか")
+    reason: str = Field(description="判定理由")
+    confidence: float = Field(ge=0.0, le=1.0, description="確信度")
+    suggested_delay_minutes: int | None = Field(
+        default=None,
+        description="推奨遅延時間（分）",
+    )
+    reply_target: ReplyTarget = Field(
+        default=ReplyTarget.THREAD,
+        description="返信先（スレッド/チャンネル）",
+    )
+```
+
+#### プロンプトの更新
+
+```python
+# integrations/llm/prompts.py の更新
+
+JUDGMENT_SYSTEM_PROMPT = """
+あなたは「にゃお」という名前のSlackボットです。
+{persona}
+
+以下のメッセージに対して、応答すべきかどうかを判定してください。
+
+## 判定基準
+
+### 応答すべき場合
+- 質問や相談が含まれている
+- 反応がなく寂しそうなメッセージ
+- 会話が途切れている
+
+### 応答すべきでない場合
+- すでに他のユーザーが反応している
+- 独り言や報告のみ
+- ボット宛てでない明確な会話
+
+## 返信先の判定
+
+### スレッドに返信する場合 (THREAD)
+- 特定の人への返答
+- 既存スレッドの話題への返答
+- 個人的な話題
+
+### チャンネルに直接投稿する場合 (CHANNEL)
+- みんなに見てもらいたい内容
+- 新しい話題の提起
+- チャンネル全体への呼びかけ
+
+## 出力形式
+
+JSON形式で以下を出力してください：
+{json_schema}
+"""
+```
+
+#### NyaoBotの更新
+
+```python
+# main.py の更新
+
+async def _send_response(
+    self,
+    message: SlackMessage,
+    context: ConversationContext,
+    decision: ResponseDecision,
+) -> None:
+    response_text = await self._response_generator.generate_response(
+        message=message,
+        context=context,
+    )
+
+    if decision.reply_target == ReplyTarget.THREAD:
+        # スレッドに返信
+        await self._message_sender.send_message(
+            channel=message.channel_id,
+            text=response_text,
+            thread_ts=message.thread_ts or message.message_id,
+        )
+    else:
+        # チャンネルに直接投稿
+        await self._message_sender.send_message(
+            channel=message.channel_id,
+            text=response_text,
+        )
+```
+
+#### テスト要件
+
+- [ ] ReplyTarget enumが正しく定義されていること
+- [ ] ResponseDecisionにreply_targetが含まれること
+- [ ] LLMがreply_targetを正しく判定すること
+- [ ] スレッドへの返信が動作すること
+- [ ] チャンネルへの直接投稿が動作すること
+
+---
+
+## ディレクトリ構成
+
+```
+nyao/
+├── config/
+│   └── settings.py              # RejudgeSettings追加
+├── core/
+│   └── models.py                # ReplyTarget enum、ResponseDecision拡張
+├── integrations/
+│   └── llm/
+│       └── prompts.py           # 返信先判定プロンプト追加
+├── services/
+│   ├── delay_controller.py      # jitter毎回計算対応
+│   └── rejudge_tracker.py       # 新規
+└── main.py                      # RejudgeTracker統合、返信先判定対応
+```
+
+---
+
+## 実装タスク
+
+### Day 1-2: jitter毎回計算対応（FR-603）
+
+- [ ] `ResponseDelayController.__init__()` のシグネチャ変更
+- [ ] `schedule_response_check()` でjitter計算
+- [ ] `NyaoBot.__init__()` の更新
+- [ ] テストの更新・実行
+
+### Day 3-4: 再判定機能（FR-601）
+
+- [ ] `RejudgeSettings` の追加
+- [ ] `RejudgeTracker` クラスの実装
+- [ ] `NyaoBot` への統合
+- [ ] テストの作成・実行
+
+### Day 5: 返信先判定（FR-602）
+
+- [ ] `ReplyTarget` enumの追加
+- [ ] `ResponseDecision` の拡張
+- [ ] プロンプトの更新
+- [ ] `NyaoBot._send_response()` の更新
+- [ ] テストの作成・実行
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+```python
+# tests/services/test_delay_controller.py
+
+@pytest.mark.asyncio
+async def test_jitter_varies_per_request():
+    """リクエストごとにjitterが異なること"""
+    delays = []
+    for _ in range(10):
+        controller.schedule_response_check(message, callback)
+        delays.append(controller._last_delay)
+    assert len(set(delays)) > 1  # 異なる値があること
+
+
+# tests/services/test_rejudge_tracker.py
+
+@pytest.mark.asyncio
+async def test_schedule_rejudge():
+    """再判定がスケジュールされること"""
+
+@pytest.mark.asyncio
+async def test_cancel_rejudge_on_new_message():
+    """新メッセージで再判定がキャンセルされること"""
+
+@pytest.mark.asyncio
+async def test_max_rejudge_count():
+    """最大回数で再判定がスケジュールされないこと"""
+
+
+# tests/core/test_models.py
+
+def test_reply_target_enum():
+    """ReplyTarget enumが正しく定義されていること"""
+
+def test_response_decision_with_reply_target():
+    """ResponseDecisionにreply_targetが含まれること"""
+```
+
+---
+
+## 完了条件
+
+- [ ] リクエストごとにjitterが適用されていること
+- [ ] 再判定機能が動作していること
+  - [ ] 指定時間後に再判定が実行されること
+  - [ ] 新メッセージで再判定がキャンセルされること
+  - [ ] 最大回数で再判定が停止すること
+- [ ] 返信先判定が動作していること
+  - [ ] ReplyTarget enumが定義されていること
+  - [ ] ResponseDecisionにreply_targetが含まれること
+  - [ ] スレッドへの返信が動作すること
+  - [ ] チャンネルへの直接投稿が動作すること
+- [ ] 全テストがパスすること
+- [ ] ruff、tyによるチェックがパスすること

--- a/specs/phase-2/03-memory-models.md
+++ b/specs/phase-2/03-memory-models.md
@@ -1,0 +1,587 @@
+# 階層的記憶管理 - データモデル設計
+
+## 概要
+
+Phase 2.4では、階層的記憶管理システムのデータモデルをSQLModelを使用して実装します。3層の記憶（ワーキングメモリ、短期記憶、長期記憶）をSQLiteデータベースに永続化します。
+
+## 実装優先度
+
+**高** - Phase 2.4の基盤となるデータ層
+
+## 依存関係
+
+### 依存先
+- Phase 2.1-2.3: LiteLLM移行、スマート応答判定
+- SQLModel、aiosqlite パッケージ
+
+### 依存元
+- Phase 2.4: 記憶管理サービス（04-memory-services.md）
+- Phase 2.4: バッチ処理（05-batch-processing.md）
+
+---
+
+## データモデル
+
+### 1. WorkingMemoryMessage - ワーキングメモリ
+
+#### 目的
+
+過去X日分のメッセージをLiteLLMメッセージ形式に近い形で保存します。
+
+#### 機能要件
+
+- **FR-101**: ワーキングメモリとして過去x日分のメッセージを保持
+- **FR-104**: チャンネル・スレッドごとの記憶を独立して管理
+
+#### スキーマ定義
+
+```python
+from datetime import datetime, UTC
+from sqlmodel import Field, SQLModel, Column, Text, JSON
+
+
+class WorkingMemoryMessage(SQLModel, table=True):
+    """ワーキングメモリ - リアルタイムメッセージ"""
+
+    __tablename__ = "working_memory"
+
+    # 主キー: Slackのメッセージタイムスタンプ
+    id: str = Field(primary_key=True)
+
+    # Slack固有の情報
+    channel_id: str = Field(index=True)
+    thread_ts: str | None = Field(default=None, index=True)
+    user_id: str = Field(index=True)
+    user_name: str
+
+    # LiteLLMメッセージ形式
+    role: str = Field(description="'user' or 'assistant'")
+    content: str = Field(sa_column=Column(Text))
+    attachments: list[dict] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="Base64エンコードされたファイル（画像等）",
+    )
+
+    # タイムスタンプ
+    timestamp: datetime = Field(index=True, description="メッセージの投稿時刻")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="レコードの作成時刻",
+    )
+```
+
+#### インデックス設計
+
+- `id`: 主キー（Slack message ts）
+- `channel_id`: チャンネルごとのメッセージ取得
+- `thread_ts`: スレッドごとのメッセージ取得
+- `user_id`: ユーザーごとのメッセージ取得
+- `timestamp`: 時系列でのメッセージ取得、古いメッセージの削除
+
+#### バリデーションルール
+
+- `role`: "user" または "assistant" のみ許可
+- `content`: 空文字列は許可（添付ファイルのみの場合）
+- `timestamp`: 未来の日時は許可しない
+
+---
+
+### 2. ThreadSummary - スレッド要約
+
+#### 目的
+
+スレッド単位の要約を保存し、短期記憶として活用します。
+
+#### 機能要件
+
+- **FR-101**: 短期記憶としてスレッド要約を保持
+- **FR-103**: 記憶を自動的に要約・圧縮
+
+#### スキーマ定義
+
+```python
+class ThreadSummary(SQLModel, table=True):
+    """スレッド要約 - 短期記憶"""
+
+    __tablename__ = "thread_summaries"
+
+    id: int | None = Field(default=None, primary_key=True)
+
+    # スレッド識別
+    thread_ts: str = Field(index=True)
+    channel_id: str = Field(index=True)
+
+    # 要約内容（LLM生成）
+    title: str = Field(description="スレッドのタイトル")
+    summary: str = Field(sa_column=Column(Text), description="スレッドの要約")
+    key_topics: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="主要トピックのリスト",
+    )
+    participants: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="参加者のuser_idリスト",
+    )
+
+    # メタデータ
+    message_count: int = Field(description="メッセージ数")
+    started_at: datetime = Field(description="スレッド開始時刻")
+    last_activity: datetime = Field(index=True, description="最終活動時刻")
+    is_resolved: bool = Field(default=False, description="解決済みかどうか")
+
+    # タイムスタンプ
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+#### インデックス設計
+
+- `id`: 主キー（自動採番）
+- `thread_ts`: スレッドの特定
+- `channel_id`: チャンネルごとのスレッド一覧
+- `last_activity`: アクティブなスレッドの取得
+
+#### 一意制約
+
+- `(thread_ts, channel_id)`: 同一スレッドの重複を防止
+
+---
+
+### 3. ChannelDailySummary - チャンネル日次要約
+
+#### 目的
+
+チャンネルの日次要約を保存し、短期記憶として活用します。
+
+#### 機能要件
+
+- **FR-101**: 短期記憶としてチャンネル日次要約を保持
+- **FR-103**: 記憶を自動的に要約・圧縮
+
+#### スキーマ定義
+
+```python
+from datetime import date
+
+
+class ChannelDailySummary(SQLModel, table=True):
+    """チャンネル日次要約 - 短期記憶"""
+
+    __tablename__ = "channel_daily_summaries"
+
+    id: int | None = Field(default=None, primary_key=True)
+
+    # チャンネル・日付
+    channel_id: str = Field(index=True)
+    date: date = Field(index=True)
+
+    # 要約内容（LLM生成）
+    summary: str = Field(sa_column=Column(Text), description="日次要約")
+    topics: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="話題のリスト",
+    )
+    mood: str = Field(description="チャンネルの雰囲気")
+
+    # メタデータ
+    message_count: int = Field(description="メッセージ数")
+    active_users: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="アクティブユーザーのuser_idリスト",
+    )
+    important_threads: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="重要スレッドのthread_tsリスト",
+    )
+
+    # タイムスタンプ
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+#### インデックス設計
+
+- `id`: 主キー（自動採番）
+- `channel_id`: チャンネルごとの要約取得
+- `date`: 日付での要約取得
+
+#### 一意制約
+
+- `(channel_id, date)`: 同一チャンネル・同一日付の重複を防止
+
+---
+
+### 4. WorkspaceMemory - ワークスペース記憶
+
+#### 目的
+
+ワークスペース全体の要約と特性を保存します（シングルトン）。
+
+#### 機能要件
+
+- **FR-101**: 長期記憶としてワークスペース要約を保持
+
+#### スキーマ定義
+
+```python
+class WorkspaceMemory(SQLModel, table=True):
+    """ワークスペース記憶 - 長期記憶（シングルトン）"""
+
+    __tablename__ = "workspace_memory"
+
+    # シングルトンとして扱う（id=1のみ）
+    id: int = Field(default=1, primary_key=True)
+
+    # 要約内容（LLM生成）
+    summary: str = Field(
+        sa_column=Column(Text),
+        description="ワークスペース全体の要約",
+    )
+    team_culture: str = Field(
+        sa_column=Column(Text),
+        description="チームの文化・雰囲気",
+    )
+    recurring_topics: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="繰り返し話題になるトピック",
+    )
+    important_events: list[dict] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="重要なイベント（日付、内容）",
+    )
+
+    # タイムスタンプ
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+#### 使用方法
+
+```python
+# 取得（なければ作成）
+async def get_or_create_workspace_memory(session: AsyncSession) -> WorkspaceMemory:
+    result = await session.get(WorkspaceMemory, 1)
+    if result is None:
+        result = WorkspaceMemory(
+            id=1,
+            summary="",
+            team_culture="",
+        )
+        session.add(result)
+        await session.commit()
+    return result
+```
+
+---
+
+### 5. ChannelLongTermMemory - チャンネル長期記憶
+
+#### 目的
+
+チャンネルの特性と履歴を保存します。
+
+#### 機能要件
+
+- **FR-101**: 長期記憶としてチャンネル特性を保持
+
+#### スキーマ定義
+
+```python
+class ChannelLongTermMemory(SQLModel, table=True):
+    """チャンネル長期記憶"""
+
+    __tablename__ = "channel_long_term_memory"
+
+    # チャンネルIDを主キーとして使用
+    channel_id: str = Field(primary_key=True)
+    channel_name: str = Field(description="チャンネル名")
+
+    # チャンネル特性（LLM生成）
+    purpose: str = Field(description="チャンネルの目的")
+    typical_topics: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="よく話題になるトピック",
+    )
+
+    # 履歴情報
+    historical_summary: str = Field(
+        sa_column=Column(Text),
+        description="過去の重要な出来事の要約",
+    )
+    important_events: list[dict] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="重要なイベント（日付、内容）",
+    )
+
+    # タイムスタンプ
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+---
+
+### 6. UserLongTermMemory - ユーザー長期記憶
+
+#### 目的
+
+ユーザーごとの特性と好みを保存します。
+
+#### 機能要件
+
+- **FR-105**: ユーザーごとの特性や好みを長期記憶に保存
+
+#### スキーマ定義
+
+```python
+class UserLongTermMemory(SQLModel, table=True):
+    """ユーザー長期記憶"""
+
+    __tablename__ = "user_long_term_memory"
+
+    # ユーザーIDを主キーとして使用
+    user_id: str = Field(primary_key=True)
+    user_name: str = Field(description="ユーザー名")
+
+    # ユーザー特性（LLM生成）
+    interests: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="興味・関心のあるトピック",
+    )
+    expertise: list[str] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="専門知識・スキル",
+    )
+
+    # タイムスタンプ
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+---
+
+## データベース初期化
+
+### DatabaseManager
+
+```python
+# memory/database.py
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+
+class DatabaseManager:
+    """データベース管理"""
+
+    def __init__(self, database_url: str = "sqlite+aiosqlite:///nyao.db") -> None:
+        """
+        データベースマネージャーを初期化する。
+
+        Args:
+            database_url: データベースURL
+        """
+        self._engine = create_async_engine(database_url, echo=False)
+        self._session_factory = sessionmaker(
+            self._engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+
+    async def init_db(self) -> None:
+        """
+        データベースを初期化する（テーブル作成）。
+        """
+        async with self._engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async def get_session(self) -> AsyncSession:
+        """
+        新しいセッションを取得する。
+
+        Returns:
+            AsyncSession: 非同期セッション
+        """
+        return self._session_factory()
+
+    @asynccontextmanager
+    async def session_scope(self) -> AsyncGenerator[AsyncSession, None]:
+        """
+        セッションスコープを提供するコンテキストマネージャー。
+
+        Yields:
+            AsyncSession: 非同期セッション
+        """
+        session = await self.get_session()
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+    async def close(self) -> None:
+        """
+        データベース接続を閉じる。
+        """
+        await self._engine.dispose()
+```
+
+### 設定
+
+```python
+# config/settings.py に追加
+
+class DatabaseSettings(BaseModel):
+    """データベース設定"""
+
+    url: str = Field(
+        default="sqlite+aiosqlite:///nyao.db",
+        description="データベースURL",
+    )
+    echo: bool = Field(
+        default=False,
+        description="SQLログを出力するか",
+    )
+
+
+class Settings(BaseSettings):
+    # 既存の設定...
+    database: DatabaseSettings = Field(default_factory=DatabaseSettings)
+```
+
+---
+
+## ディレクトリ構成
+
+```
+nyao/
+├── memory/
+│   ├── __init__.py
+│   ├── models.py      # 全データモデル
+│   └── database.py    # DatabaseManager
+```
+
+---
+
+## 実装タスク
+
+### Day 1: モデル定義
+
+- [ ] `memory/models.py` の作成
+- [ ] `WorkingMemoryMessage` の実装
+- [ ] `ThreadSummary` の実装
+- [ ] `ChannelDailySummary` の実装
+- [ ] `WorkspaceMemory` の実装
+- [ ] `ChannelLongTermMemory` の実装
+- [ ] `UserLongTermMemory` の実装
+
+### Day 2: データベース初期化
+
+- [ ] `memory/database.py` の作成
+- [ ] `DatabaseManager` の実装
+- [ ] 設定への `DatabaseSettings` の追加
+- [ ] 依存パッケージの追加（sqlmodel, aiosqlite）
+- [ ] テストの作成・実行
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+```python
+# tests/memory/test_models.py
+
+def test_working_memory_message_creation():
+    """WorkingMemoryMessageが正しく作成されること"""
+    msg = WorkingMemoryMessage(
+        id="1234567890.123456",
+        channel_id="C123",
+        user_id="U123",
+        user_name="test_user",
+        role="user",
+        content="Hello",
+        timestamp=datetime.now(UTC),
+    )
+    assert msg.id == "1234567890.123456"
+    assert msg.role == "user"
+
+
+def test_thread_summary_creation():
+    """ThreadSummaryが正しく作成されること"""
+
+
+def test_channel_daily_summary_creation():
+    """ChannelDailySummaryが正しく作成されること"""
+
+
+# tests/memory/test_database.py
+
+@pytest.mark.asyncio
+async def test_database_initialization():
+    """データベースが正しく初期化されること"""
+    db = DatabaseManager("sqlite+aiosqlite:///:memory:")
+    await db.init_db()
+    # テーブルが作成されていることを確認
+
+
+@pytest.mark.asyncio
+async def test_session_scope():
+    """セッションスコープが正しく動作すること"""
+
+
+@pytest.mark.asyncio
+async def test_crud_operations():
+    """CRUD操作が正しく動作すること"""
+```
+
+### インメモリデータベースを使用したテスト
+
+```python
+@pytest.fixture
+async def db_manager():
+    """テスト用データベースマネージャー"""
+    manager = DatabaseManager("sqlite+aiosqlite:///:memory:")
+    await manager.init_db()
+    yield manager
+    await manager.close()
+```
+
+---
+
+## 依存パッケージ
+
+```toml
+[project.dependencies]
+sqlmodel = ">=0.0.22"
+aiosqlite = ">=0.19.0"
+```
+
+---
+
+## 完了条件
+
+- [ ] すべてのデータモデルが定義されていること
+  - [ ] WorkingMemoryMessage
+  - [ ] ThreadSummary
+  - [ ] ChannelDailySummary
+  - [ ] WorkspaceMemory
+  - [ ] ChannelLongTermMemory
+  - [ ] UserLongTermMemory
+- [ ] DatabaseManagerが実装されていること
+- [ ] データベースが正しく初期化されること
+- [ ] CRUD操作が動作すること
+- [ ] 全テストがパスすること
+- [ ] ruff、tyによるチェックがパスすること

--- a/specs/phase-2/04-memory-services.md
+++ b/specs/phase-2/04-memory-services.md
@@ -1,0 +1,759 @@
+# 階層的記憶管理 - サービス設計
+
+## 概要
+
+Phase 2.4では、階層的記憶管理システムのサービス層を実装します。各記憶層（ワーキングメモリ、短期記憶、長期記憶）へのアクセスを抽象化し、プロンプトコンテキストの構築を行います。
+
+## 実装優先度
+
+**高** - データモデル（03-memory-models.md）の実装後に実装
+
+## 依存関係
+
+### 依存先
+- Phase 2.4: データモデル（03-memory-models.md）
+- Phase 2.1: LiteLLM直接使用（NyaoAgent）
+
+### 依存元
+- Phase 2.4: バッチ処理（05-batch-processing.md）
+- NyaoBot（main.py）
+
+---
+
+## コンポーネント
+
+### 1. WorkingMemoryService - ワーキングメモリサービス
+
+#### 目的
+
+ワーキングメモリ（過去X日分のメッセージ）の保存・取得・管理を行います。
+
+#### 機能要件
+
+- **FR-101**: ワーキングメモリとして過去x日分のメッセージを保持
+- **FR-104**: チャンネル・スレッドごとの記憶を独立して管理
+
+#### 実装方針
+
+SlackMessageをWorkingMemoryMessageに変換してデータベースに保存し、LiteLLMメッセージ形式で取得できるようにします。
+
+#### 主要インターフェース
+
+```python
+class WorkingMemoryService:
+    """ワーキングメモリサービス"""
+
+    def __init__(
+        self,
+        db_manager: DatabaseManager,
+        retention_days: int = 7,
+    ) -> None:
+        """
+        ワーキングメモリサービスを初期化する。
+
+        Args:
+            db_manager: データベースマネージャー
+            retention_days: メッセージ保持日数
+        """
+
+    async def save_message(self, message: SlackMessage) -> WorkingMemoryMessage:
+        """
+        Slackメッセージを保存する。
+
+        Args:
+            message: Slackメッセージ
+
+        Returns:
+            WorkingMemoryMessage: 保存されたメッセージ
+        """
+
+    async def save_bot_response(
+        self,
+        channel_id: str,
+        thread_ts: str | None,
+        content: str,
+        message_ts: str,
+    ) -> WorkingMemoryMessage:
+        """
+        ボットの応答を保存する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+            content: 応答内容
+            message_ts: メッセージタイムスタンプ
+
+        Returns:
+            WorkingMemoryMessage: 保存されたメッセージ
+        """
+
+    async def get_messages_for_context(
+        self,
+        channel_id: str,
+        thread_ts: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, str]]:
+        """
+        LiteLLMメッセージ形式でメッセージを取得する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ（Noneの場合はチャンネル全体）
+            limit: 取得するメッセージ数の上限
+
+        Returns:
+            list[dict[str, str]]: LiteLLMメッセージ形式のリスト
+                [{"role": "user", "content": "..."}, ...]
+        """
+
+    async def get_recent_messages(
+        self,
+        channel_id: str,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> list[WorkingMemoryMessage]:
+        """
+        最近のメッセージを取得する。
+
+        Args:
+            channel_id: チャンネルID
+            since: この日時以降のメッセージを取得
+            limit: 取得するメッセージ数の上限
+
+        Returns:
+            list[WorkingMemoryMessage]: メッセージのリスト
+        """
+
+    async def cleanup_old_messages(self) -> int:
+        """
+        古いメッセージを削除する。
+
+        Returns:
+            int: 削除されたメッセージ数
+        """
+
+    def _convert_to_litellm_format(
+        self,
+        messages: list[WorkingMemoryMessage],
+    ) -> list[dict[str, str]]:
+        """
+        WorkingMemoryMessageをLiteLLMメッセージ形式に変換する。
+        """
+```
+
+#### テスト要件
+
+- [ ] メッセージが正しく保存されること
+- [ ] ボットの応答が正しく保存されること
+- [ ] LiteLLMメッセージ形式で取得できること
+- [ ] チャンネル・スレッドごとにフィルタリングされること
+- [ ] 古いメッセージが削除されること
+
+---
+
+### 2. ShortTermMemoryService - 短期記憶サービス
+
+#### 目的
+
+短期記憶（スレッド要約、チャンネル日次要約）の保存・取得・管理を行います。
+
+#### 機能要件
+
+- **FR-101**: 短期記憶としてスレッド要約、チャンネル日次要約を保持
+- **FR-103**: 記憶を自動的に要約・圧縮
+
+#### 主要インターフェース
+
+```python
+class ShortTermMemoryService:
+    """短期記憶サービス"""
+
+    def __init__(self, db_manager: DatabaseManager) -> None:
+        """
+        短期記憶サービスを初期化する。
+
+        Args:
+            db_manager: データベースマネージャー
+        """
+
+    # スレッド要約
+
+    async def get_thread_summary(
+        self,
+        channel_id: str,
+        thread_ts: str,
+    ) -> ThreadSummary | None:
+        """
+        スレッド要約を取得する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+
+        Returns:
+            ThreadSummary | None: スレッド要約（存在しない場合はNone）
+        """
+
+    async def save_thread_summary(
+        self,
+        summary: ThreadSummary,
+    ) -> ThreadSummary:
+        """
+        スレッド要約を保存する（作成または更新）。
+
+        Args:
+            summary: スレッド要約
+
+        Returns:
+            ThreadSummary: 保存されたスレッド要約
+        """
+
+    async def get_active_thread_summaries(
+        self,
+        channel_id: str,
+        since: datetime | None = None,
+        limit: int = 10,
+    ) -> list[ThreadSummary]:
+        """
+        アクティブなスレッド要約を取得する。
+
+        Args:
+            channel_id: チャンネルID
+            since: この日時以降のスレッドを取得
+            limit: 取得するスレッド数の上限
+
+        Returns:
+            list[ThreadSummary]: スレッド要約のリスト
+        """
+
+    # チャンネル日次要約
+
+    async def get_channel_daily_summary(
+        self,
+        channel_id: str,
+        target_date: date,
+    ) -> ChannelDailySummary | None:
+        """
+        チャンネル日次要約を取得する。
+
+        Args:
+            channel_id: チャンネルID
+            target_date: 対象日付
+
+        Returns:
+            ChannelDailySummary | None: 日次要約（存在しない場合はNone）
+        """
+
+    async def save_channel_daily_summary(
+        self,
+        summary: ChannelDailySummary,
+    ) -> ChannelDailySummary:
+        """
+        チャンネル日次要約を保存する（作成または更新）。
+
+        Args:
+            summary: チャンネル日次要約
+
+        Returns:
+            ChannelDailySummary: 保存された日次要約
+        """
+
+    async def get_recent_daily_summaries(
+        self,
+        channel_id: str,
+        days: int = 7,
+    ) -> list[ChannelDailySummary]:
+        """
+        最近のチャンネル日次要約を取得する。
+
+        Args:
+            channel_id: チャンネルID
+            days: 取得する日数
+
+        Returns:
+            list[ChannelDailySummary]: 日次要約のリスト（新しい順）
+        """
+
+    async def get_missing_daily_summary_dates(
+        self,
+        channel_id: str,
+        days: int = 7,
+    ) -> list[date]:
+        """
+        日次要約が存在しない日付のリストを取得する。
+
+        Args:
+            channel_id: チャンネルID
+            days: チェックする日数
+
+        Returns:
+            list[date]: 日次要約が存在しない日付のリスト
+        """
+```
+
+#### テスト要件
+
+- [ ] スレッド要約が正しく保存・取得されること
+- [ ] チャンネル日次要約が正しく保存・取得されること
+- [ ] 最近の要約が正しくフィルタリングされること
+- [ ] 欠落している日次要約の日付が取得できること
+
+---
+
+### 3. LongTermMemoryService - 長期記憶サービス
+
+#### 目的
+
+長期記憶（ワークスペース記憶、チャンネル特性、ユーザー特性）の保存・取得・管理を行います。
+
+#### 機能要件
+
+- **FR-101**: 長期記憶としてワークスペース要約、チャンネル特性、ユーザー特性を保持
+- **FR-105**: ユーザーごとの特性や好みを長期記憶に保存
+
+#### 主要インターフェース
+
+```python
+class LongTermMemoryService:
+    """長期記憶サービス"""
+
+    def __init__(self, db_manager: DatabaseManager) -> None:
+        """
+        長期記憶サービスを初期化する。
+
+        Args:
+            db_manager: データベースマネージャー
+        """
+
+    # ワークスペース記憶
+
+    async def get_workspace_memory(self) -> WorkspaceMemory:
+        """
+        ワークスペース記憶を取得する（なければ作成）。
+
+        Returns:
+            WorkspaceMemory: ワークスペース記憶
+        """
+
+    async def save_workspace_memory(
+        self,
+        memory: WorkspaceMemory,
+    ) -> WorkspaceMemory:
+        """
+        ワークスペース記憶を保存する。
+
+        Args:
+            memory: ワークスペース記憶
+
+        Returns:
+            WorkspaceMemory: 保存されたワークスペース記憶
+        """
+
+    # チャンネル長期記憶
+
+    async def get_channel_memory(
+        self,
+        channel_id: str,
+    ) -> ChannelLongTermMemory | None:
+        """
+        チャンネル長期記憶を取得する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            ChannelLongTermMemory | None: チャンネル長期記憶
+        """
+
+    async def save_channel_memory(
+        self,
+        memory: ChannelLongTermMemory,
+    ) -> ChannelLongTermMemory:
+        """
+        チャンネル長期記憶を保存する（作成または更新）。
+
+        Args:
+            memory: チャンネル長期記憶
+
+        Returns:
+            ChannelLongTermMemory: 保存されたチャンネル長期記憶
+        """
+
+    async def get_all_channel_memories(self) -> list[ChannelLongTermMemory]:
+        """
+        すべてのチャンネル長期記憶を取得する。
+
+        Returns:
+            list[ChannelLongTermMemory]: チャンネル長期記憶のリスト
+        """
+
+    # ユーザー長期記憶
+
+    async def get_user_memory(
+        self,
+        user_id: str,
+    ) -> UserLongTermMemory | None:
+        """
+        ユーザー長期記憶を取得する。
+
+        Args:
+            user_id: ユーザーID
+
+        Returns:
+            UserLongTermMemory | None: ユーザー長期記憶
+        """
+
+    async def save_user_memory(
+        self,
+        memory: UserLongTermMemory,
+    ) -> UserLongTermMemory:
+        """
+        ユーザー長期記憶を保存する（作成または更新）。
+
+        Args:
+            memory: ユーザー長期記憶
+
+        Returns:
+            UserLongTermMemory: 保存されたユーザー長期記憶
+        """
+
+    async def get_user_memories_for_channel(
+        self,
+        channel_id: str,
+        user_ids: list[str],
+    ) -> list[UserLongTermMemory]:
+        """
+        指定されたユーザーの長期記憶を取得する。
+
+        Args:
+            channel_id: チャンネルID（フィルタリング用）
+            user_ids: ユーザーIDのリスト
+
+        Returns:
+            list[UserLongTermMemory]: ユーザー長期記憶のリスト
+        """
+```
+
+#### テスト要件
+
+- [ ] ワークスペース記憶が正しく保存・取得されること
+- [ ] チャンネル長期記憶が正しく保存・取得されること
+- [ ] ユーザー長期記憶が正しく保存・取得されること
+
+---
+
+### 4. MemoryContextBuilder - プロンプトコンテキスト構築
+
+#### 目的
+
+階層的記憶を組み合わせて、プロンプト用のコンテキストを構築します。
+
+#### 機能要件
+
+- **FR-102**: 過去の会話履歴を参照して、コンテキストに応じた応答を生成
+- **FR-103**: LLMのコンテキストウィンドウを効率的に使用
+
+#### 実装方針
+
+階層的記憶を以下の優先順位で組み合わせ、トークン数制限（8000トークン）内に収めます。
+
+1. **長期記憶**（優先度: 高、圧縮率: 高）
+   - ワークスペース全体の要約・特性
+   - チャンネルの要約・特性
+
+2. **短期記憶**（優先度: 中、圧縮率: 中）
+   - チャンネル日次要約（過去x日分）
+   - スレッド要約・タイトル
+
+3. **ワーキングメモリ**（優先度: 高、圧縮率: 低）
+   - 直近のメッセージ（生データ）
+
+#### 主要インターフェース
+
+```python
+class MemoryContextBuilder:
+    """階層的記憶からプロンプトコンテキストを構築"""
+
+    DEFAULT_MAX_TOKENS: int = 8000
+    TOKENS_PER_CHAR: float = 0.25  # 概算（日本語の場合）
+
+    def __init__(
+        self,
+        working_memory: WorkingMemoryService,
+        short_term: ShortTermMemoryService,
+        long_term: LongTermMemoryService,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        """
+        コンテキストビルダーを初期化する。
+
+        Args:
+            working_memory: ワーキングメモリサービス
+            short_term: 短期記憶サービス
+            long_term: 長期記憶サービス
+            max_tokens: 最大トークン数
+        """
+
+    async def build_context(
+        self,
+        channel_id: str,
+        thread_ts: str | None = None,
+        include_user_memory: bool = True,
+    ) -> MemoryContext:
+        """
+        プロンプト用のコンテキストを構築する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+            include_user_memory: ユーザー記憶を含めるか
+
+        Returns:
+            MemoryContext: 構築されたコンテキスト
+        """
+
+    async def build_messages_for_llm(
+        self,
+        channel_id: str,
+        thread_ts: str | None = None,
+    ) -> list[dict[str, str]]:
+        """
+        LLM用のメッセージリストを構築する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+
+        Returns:
+            list[dict[str, str]]: LLMメッセージ形式のリスト
+        """
+
+    def _estimate_tokens(self, text: str) -> int:
+        """
+        テキストのトークン数を推定する。
+
+        Args:
+            text: テキスト
+
+        Returns:
+            int: 推定トークン数
+        """
+
+    def _truncate_to_token_limit(
+        self,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+    ) -> list[dict[str, str]]:
+        """
+        トークン制限に収まるようにメッセージを切り詰める。
+        古いメッセージから削除する。
+
+        Args:
+            messages: メッセージリスト
+            max_tokens: 最大トークン数
+
+        Returns:
+            list[dict[str, str]]: 切り詰められたメッセージリスト
+        """
+
+    async def _build_long_term_context(
+        self,
+        channel_id: str,
+    ) -> str:
+        """長期記憶からコンテキストを構築する"""
+
+    async def _build_short_term_context(
+        self,
+        channel_id: str,
+        thread_ts: str | None,
+    ) -> str:
+        """短期記憶からコンテキストを構築する"""
+
+    async def _build_working_memory_context(
+        self,
+        channel_id: str,
+        thread_ts: str | None,
+    ) -> list[dict[str, str]]:
+        """ワーキングメモリからコンテキストを構築する"""
+```
+
+#### MemoryContext データクラス
+
+```python
+@dataclass
+class MemoryContext:
+    """記憶コンテキスト"""
+
+    # 長期記憶
+    workspace_summary: str
+    channel_summary: str
+    channel_characteristics: str
+
+    # 短期記憶
+    recent_daily_summaries: list[str]
+    thread_summaries: list[str]
+
+    # ワーキングメモリ
+    recent_messages: list[dict[str, str]]
+
+    # メタデータ
+    total_tokens: int
+    truncated: bool
+
+    def to_system_prompt_section(self) -> str:
+        """システムプロンプト用のセクションに変換する"""
+
+    def to_messages(self) -> list[dict[str, str]]:
+        """LLMメッセージ形式に変換する"""
+```
+
+#### テスト要件
+
+- [ ] コンテキストが正しく構築されること
+- [ ] トークン数制限が守られること
+- [ ] 階層的記憶が正しい優先順位で組み込まれること
+- [ ] 古いメッセージから切り詰められること
+
+---
+
+## 既存サービスとの統合
+
+### ContextManagerServiceからの移行
+
+Phase 1の`ContextManagerService`はインメモリでコンテキストを管理していました。Phase 2では、以下のように段階的に移行します。
+
+1. **WorkingMemoryService**がメッセージの永続化を担当
+2. **MemoryContextBuilder**がコンテキスト構築を担当
+3. **ContextManagerService**は廃止または薄いラッパーとして維持
+
+```python
+# services/context_manager.py の更新
+
+class ContextManagerService:
+    """コンテキスト管理サービス（Phase 2対応）"""
+
+    def __init__(
+        self,
+        working_memory: WorkingMemoryService,
+        context_builder: MemoryContextBuilder,
+    ) -> None:
+        self._working_memory = working_memory
+        self._context_builder = context_builder
+
+    async def add_message(self, message: SlackMessage) -> None:
+        """メッセージを追加する（DBに保存）"""
+        await self._working_memory.save_message(message)
+
+    async def get_context(
+        self,
+        channel_id: str,
+        thread_ts: str | None = None,
+    ) -> MemoryContext:
+        """コンテキストを取得する"""
+        return await self._context_builder.build_context(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+        )
+```
+
+---
+
+## ディレクトリ構成
+
+```
+nyao/
+├── memory/
+│   ├── __init__.py
+│   ├── models.py              # データモデル（03-memory-models.md）
+│   ├── database.py            # DatabaseManager
+│   ├── working_memory.py      # WorkingMemoryService
+│   ├── short_term.py          # ShortTermMemoryService
+│   ├── long_term.py           # LongTermMemoryService
+│   └── context_builder.py     # MemoryContextBuilder
+├── services/
+│   └── context_manager.py     # 更新（Phase 2対応）
+```
+
+---
+
+## 実装タスク
+
+### Day 3: WorkingMemoryServiceの実装
+
+- [ ] `memory/working_memory.py` の作成
+- [ ] `save_message()` の実装
+- [ ] `save_bot_response()` の実装
+- [ ] `get_messages_for_context()` の実装
+- [ ] `cleanup_old_messages()` の実装
+- [ ] テストの作成・実行
+
+### Day 4: ShortTermMemoryServiceとLongTermMemoryServiceの実装
+
+- [ ] `memory/short_term.py` の作成
+- [ ] `memory/long_term.py` の作成
+- [ ] 各メソッドの実装
+- [ ] テストの作成・実行
+
+### Day 5: MemoryContextBuilderの実装
+
+- [ ] `memory/context_builder.py` の作成
+- [ ] `build_context()` の実装
+- [ ] `build_messages_for_llm()` の実装
+- [ ] トークン数推定・制限の実装
+- [ ] テストの作成・実行
+- [ ] ContextManagerServiceの更新
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+```python
+# tests/memory/test_working_memory.py
+
+@pytest.mark.asyncio
+async def test_save_and_get_message(db_manager):
+    """メッセージの保存と取得"""
+    service = WorkingMemoryService(db_manager)
+    message = create_test_slack_message()
+    await service.save_message(message)
+    messages = await service.get_messages_for_context(
+        channel_id=message.channel_id,
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_messages(db_manager):
+    """古いメッセージの削除"""
+
+
+# tests/memory/test_context_builder.py
+
+@pytest.mark.asyncio
+async def test_build_context_within_token_limit(memory_services):
+    """トークン制限内でコンテキストが構築されること"""
+    builder = MemoryContextBuilder(**memory_services)
+    context = await builder.build_context(channel_id="C123")
+    assert context.total_tokens <= 8000
+
+
+@pytest.mark.asyncio
+async def test_truncate_old_messages(memory_services):
+    """古いメッセージが切り詰められること"""
+```
+
+---
+
+## 完了条件
+
+- [ ] WorkingMemoryServiceが実装されていること
+- [ ] ShortTermMemoryServiceが実装されていること
+- [ ] LongTermMemoryServiceが実装されていること
+- [ ] MemoryContextBuilderが実装されていること
+- [ ] トークン数制限が守られること（8000トークン以内）
+- [ ] ContextManagerServiceがPhase 2対応に更新されていること
+- [ ] 全テストがパスすること
+- [ ] ruff、tyによるチェックがパスすること

--- a/specs/phase-2/05-batch-processing.md
+++ b/specs/phase-2/05-batch-processing.md
@@ -1,0 +1,701 @@
+# 日次要約バッチ処理
+
+## 概要
+
+Phase 2.4では、日次要約バッチ処理を実装します。定期的にチャンネルの活動を要約し、短期記憶と長期記憶を更新します。
+
+## 実装優先度
+
+**中** - 記憶管理サービス（04-memory-services.md）の実装後に実装
+
+## 依存関係
+
+### 依存先
+- Phase 2.4: 記憶管理サービス（04-memory-services.md）
+- Phase 2.1: LiteLLM直接使用（NyaoAgent）
+
+### 依存元
+- NyaoBot（main.py）
+
+---
+
+## コンポーネント
+
+### 1. MemorySummarizer - 記憶要約サービス
+
+#### 目的
+
+LLMを使用して、各種記憶の要約を生成します。
+
+#### 機能要件
+
+- **FR-103**: LLMのコンテキストウィンドウを効率的に使用するため、記憶を自動的に要約・圧縮
+
+#### 主要インターフェース
+
+```python
+class MemorySummarizer:
+    """記憶要約サービス"""
+
+    def __init__(
+        self,
+        agent: NyaoAgent,
+        working_memory: WorkingMemoryService,
+        short_term: ShortTermMemoryService,
+        long_term: LongTermMemoryService,
+    ) -> None:
+        """
+        記憶要約サービスを初期化する。
+
+        Args:
+            agent: LLMエージェント
+            working_memory: ワーキングメモリサービス
+            short_term: 短期記憶サービス
+            long_term: 長期記憶サービス
+        """
+
+    # スレッド要約
+
+    async def summarize_thread(
+        self,
+        channel_id: str,
+        thread_ts: str,
+    ) -> ThreadSummary:
+        """
+        スレッドを要約する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+
+        Returns:
+            ThreadSummary: 生成されたスレッド要約
+        """
+
+    async def should_update_thread_summary(
+        self,
+        channel_id: str,
+        thread_ts: str,
+    ) -> bool:
+        """
+        スレッド要約を更新すべきか判定する。
+
+        Args:
+            channel_id: チャンネルID
+            thread_ts: スレッドタイムスタンプ
+
+        Returns:
+            bool: 更新すべき場合True
+        """
+
+    # チャンネル日次要約
+
+    async def summarize_channel_daily(
+        self,
+        channel_id: str,
+        target_date: date,
+    ) -> ChannelDailySummary:
+        """
+        チャンネルの日次要約を生成する。
+
+        Args:
+            channel_id: チャンネルID
+            target_date: 対象日付
+
+        Returns:
+            ChannelDailySummary: 生成された日次要約
+        """
+
+    # 長期記憶の更新
+
+    async def update_workspace_memory(self) -> WorkspaceMemory:
+        """
+        ワークスペース記憶を更新する。
+
+        Returns:
+            WorkspaceMemory: 更新されたワークスペース記憶
+        """
+
+    async def update_channel_long_term(
+        self,
+        channel_id: str,
+    ) -> ChannelLongTermMemory:
+        """
+        チャンネル長期記憶を更新する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            ChannelLongTermMemory: 更新されたチャンネル長期記憶
+        """
+
+    async def update_user_long_term(
+        self,
+        user_id: str,
+    ) -> UserLongTermMemory:
+        """
+        ユーザー長期記憶を更新する。
+
+        Args:
+            user_id: ユーザーID
+
+        Returns:
+            UserLongTermMemory: 更新されたユーザー長期記憶
+        """
+```
+
+#### テスト要件
+
+- [ ] スレッド要約が正しく生成されること
+- [ ] チャンネル日次要約が正しく生成されること
+- [ ] ワークスペース記憶が正しく更新されること
+- [ ] チャンネル長期記憶が正しく更新されること
+- [ ] ユーザー長期記憶が正しく更新されること
+
+---
+
+### 2. 要約用プロンプトテンプレート
+
+#### スレッド要約プロンプト
+
+```python
+THREAD_SUMMARY_PROMPT = """
+以下のスレッドの会話を要約してください。
+
+## 会話内容
+{messages}
+
+## 出力形式
+JSON形式で以下を出力してください：
+{
+    "title": "スレッドのタイトル（20文字以内）",
+    "summary": "スレッドの要約（200文字以内）",
+    "key_topics": ["トピック1", "トピック2", ...],
+    "is_resolved": true/false（質問や課題が解決したかどうか）
+}
+"""
+```
+
+#### チャンネル日次要約プロンプト
+
+```python
+CHANNEL_DAILY_SUMMARY_PROMPT = """
+以下は{date}の{channel_name}チャンネルの活動です。
+
+## メッセージ数
+{message_count}件
+
+## アクティブユーザー
+{active_users}
+
+## 主要なスレッド
+{thread_summaries}
+
+## 出力形式
+JSON形式で以下を出力してください：
+{
+    "summary": "日次要約（300文字以内）",
+    "topics": ["話題1", "話題2", ...],
+    "mood": "チャンネルの雰囲気（例: 活発、落ち着いている、etc.）",
+    "important_threads": ["thread_ts1", "thread_ts2", ...]
+}
+"""
+```
+
+#### チャンネル特性抽出プロンプト
+
+```python
+CHANNEL_CHARACTERISTICS_PROMPT = """
+以下は{channel_name}チャンネルの過去の活動履歴です。
+
+## 日次要約履歴
+{daily_summaries}
+
+## 現在のチャンネル特性（あれば）
+{current_characteristics}
+
+## 出力形式
+JSON形式で以下を出力してください：
+{
+    "purpose": "チャンネルの目的",
+    "typical_topics": ["よくある話題1", "話題2", ...],
+    "historical_summary": "過去の重要な出来事の要約"
+}
+"""
+```
+
+#### ユーザー特性抽出プロンプト
+
+```python
+USER_CHARACTERISTICS_PROMPT = """
+以下は{user_name}さんの過去のメッセージ履歴です。
+
+## メッセージ履歴
+{messages}
+
+## 現在のユーザー特性（あれば）
+{current_characteristics}
+
+## 出力形式
+JSON形式で以下を出力してください：
+{
+    "interests": ["興味1", "興味2", ...],
+    "expertise": ["専門知識1", "スキル2", ...]
+}
+"""
+```
+
+---
+
+### 3. BatchProcessor - バッチ処理
+
+#### 目的
+
+定期的に要約生成バッチ処理を実行します。
+
+#### 機能要件
+
+- 10分間隔で実行
+- チャンネルごとに変更検知（最終更新時刻を追跡）
+- 当日分: 変更があれば更新
+- 過去X日分: 存在しなければ作成
+
+#### 実装方針
+
+```python
+class BatchProcessor:
+    """日次要約バッチ処理"""
+
+    DEFAULT_INTERVAL_SECONDS: int = 600  # 10分
+    DEFAULT_LOOKBACK_DAYS: int = 7
+
+    def __init__(
+        self,
+        summarizer: MemorySummarizer,
+        working_memory: WorkingMemoryService,
+        short_term: ShortTermMemoryService,
+        slack_client: SlackConnectionManager,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    ) -> None:
+        self._summarizer = summarizer
+        self._working_memory = working_memory
+        self._short_term = short_term
+        self._slack_client = slack_client
+        self._interval_seconds = interval_seconds
+        self._lookback_days = lookback_days
+        self._running = False
+        self._task: asyncio.Task | None = None
+        self._last_processed: dict[str, datetime] = {}
+```
+
+#### 主要インターフェース
+
+```python
+class BatchProcessor:
+    """日次要約バッチ処理"""
+
+    async def start(self) -> None:
+        """
+        バッチ処理ループを開始する。
+        """
+
+    async def stop(self) -> None:
+        """
+        バッチ処理ループを停止する。
+        """
+
+    async def run_once(self) -> BatchResult:
+        """
+        バッチ処理を1回実行する。
+
+        Returns:
+            BatchResult: 処理結果
+        """
+
+    async def _process_loop(self) -> None:
+        """
+        バッチ処理ループ（内部メソッド）。
+        """
+
+    async def _get_active_channels(self) -> list[str]:
+        """
+        アクティブなチャンネルIDのリストを取得する。
+
+        Returns:
+            list[str]: チャンネルIDのリスト
+        """
+
+    async def _process_channel(self, channel_id: str) -> ChannelBatchResult:
+        """
+        チャンネルの要約処理を実行する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            ChannelBatchResult: 処理結果
+        """
+
+    async def _has_channel_changes(
+        self,
+        channel_id: str,
+        since: datetime,
+    ) -> bool:
+        """
+        チャンネルに変更があるか確認する。
+
+        Args:
+            channel_id: チャンネルID
+            since: この日時以降の変更を確認
+
+        Returns:
+            bool: 変更がある場合True
+        """
+
+    async def _process_today_summary(
+        self,
+        channel_id: str,
+    ) -> ChannelDailySummary | None:
+        """
+        当日の日次要約を処理する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            ChannelDailySummary | None: 更新された場合は日次要約
+        """
+
+    async def _process_missing_summaries(
+        self,
+        channel_id: str,
+    ) -> list[ChannelDailySummary]:
+        """
+        欠落している日次要約を処理する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            list[ChannelDailySummary]: 作成された日次要約のリスト
+        """
+
+    async def _process_thread_summaries(
+        self,
+        channel_id: str,
+    ) -> list[ThreadSummary]:
+        """
+        スレッド要約を処理する。
+
+        Args:
+            channel_id: チャンネルID
+
+        Returns:
+            list[ThreadSummary]: 更新されたスレッド要約のリスト
+        """
+
+    async def _update_long_term_memories(self) -> None:
+        """
+        長期記憶を更新する（低頻度で実行）。
+        """
+```
+
+#### BatchResult データクラス
+
+```python
+@dataclass
+class ChannelBatchResult:
+    """チャンネルのバッチ処理結果"""
+    channel_id: str
+    today_summary_updated: bool
+    missing_summaries_created: int
+    thread_summaries_updated: int
+    errors: list[str]
+
+
+@dataclass
+class BatchResult:
+    """バッチ処理結果"""
+    started_at: datetime
+    completed_at: datetime
+    channels_processed: int
+    channel_results: list[ChannelBatchResult]
+    long_term_updated: bool
+    errors: list[str]
+
+    @property
+    def success(self) -> bool:
+        """処理が成功したか"""
+        return len(self.errors) == 0
+
+    @property
+    def duration_seconds(self) -> float:
+        """処理時間（秒）"""
+        return (self.completed_at - self.started_at).total_seconds()
+```
+
+#### テスト要件
+
+- [ ] バッチ処理が正常に実行されること
+- [ ] 変更検知が動作すること
+- [ ] 当日分の更新が動作すること
+- [ ] 欠落している日次要約が作成されること
+- [ ] グレースフルシャットダウンが動作すること
+- [ ] エラー発生時も処理が継続すること
+
+---
+
+### 4. NyaoBotへの統合
+
+#### main.pyの更新
+
+```python
+class NyaoBot:
+    def __init__(self, ...):
+        # 既存の初期化...
+
+        # バッチ処理の初期化
+        self._batch_processor = BatchProcessor(
+            summarizer=self._summarizer,
+            working_memory=self._working_memory,
+            short_term=self._short_term,
+            slack_client=self._slack_connection,
+            interval_seconds=settings.bot.batch.interval_seconds,
+        )
+
+    async def start(self) -> None:
+        """アプリケーションを起動する"""
+        # データベースの初期化
+        await self._db_manager.init_db()
+
+        # Slack接続の開始
+        await self._slack_connection.start()
+
+        # バッチ処理の開始
+        await self._batch_processor.start()
+
+        # クリーンアップループの開始
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+
+    async def stop(self) -> None:
+        """アプリケーションを停止する"""
+        # バッチ処理の停止
+        await self._batch_processor.stop()
+
+        # 既存の停止処理...
+```
+
+#### 設定
+
+```python
+# config/settings.py に追加
+
+class BatchSettings(BaseModel):
+    """バッチ処理設定"""
+
+    interval_seconds: int = Field(
+        default=600,
+        ge=60,
+        le=3600,
+        description="バッチ処理の実行間隔（秒）",
+    )
+    lookback_days: int = Field(
+        default=7,
+        ge=1,
+        le=30,
+        description="過去の日次要約をチェックする日数",
+    )
+    long_term_update_interval_hours: int = Field(
+        default=24,
+        ge=1,
+        le=168,
+        description="長期記憶の更新間隔（時間）",
+    )
+
+
+class BotSettings(BaseModel):
+    # 既存の設定...
+    batch: BatchSettings = Field(default_factory=BatchSettings)
+```
+
+---
+
+## ディレクトリ構成
+
+```
+nyao/
+├── memory/
+│   ├── __init__.py
+│   ├── models.py              # データモデル
+│   ├── database.py            # DatabaseManager
+│   ├── working_memory.py      # WorkingMemoryService
+│   ├── short_term.py          # ShortTermMemoryService
+│   ├── long_term.py           # LongTermMemoryService
+│   ├── context_builder.py     # MemoryContextBuilder
+│   ├── summarizer.py          # MemorySummarizer
+│   └── batch_processor.py     # BatchProcessor
+├── integrations/
+│   └── llm/
+│       └── prompts.py         # 要約用プロンプト追加
+├── config/
+│   └── settings.py            # BatchSettings追加
+└── main.py                    # BatchProcessor統合
+```
+
+---
+
+## 実装タスク
+
+### Day 1-2: MemorySummarizerの実装
+
+- [ ] `memory/summarizer.py` の作成
+- [ ] 要約用プロンプトテンプレートの追加
+- [ ] `summarize_thread()` の実装
+- [ ] `summarize_channel_daily()` の実装
+- [ ] `update_workspace_memory()` の実装
+- [ ] `update_channel_long_term()` の実装
+- [ ] `update_user_long_term()` の実装
+- [ ] テストの作成・実行
+
+### Day 3: BatchProcessorの実装
+
+- [ ] `memory/batch_processor.py` の作成
+- [ ] `BatchSettings` の追加
+- [ ] `start()` / `stop()` の実装
+- [ ] `run_once()` の実装
+- [ ] `_process_channel()` の実装
+- [ ] 変更検知ロジックの実装
+- [ ] テストの作成・実行
+
+### Day 4: NyaoBotへの統合
+
+- [ ] `main.py` の更新
+- [ ] バッチ処理の起動・停止
+- [ ] グレースフルシャットダウン対応
+- [ ] 統合テストの実行
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+```python
+# tests/memory/test_summarizer.py
+
+@pytest.mark.asyncio
+async def test_summarize_thread(mock_agent, memory_services):
+    """スレッド要約が正しく生成されること"""
+    summarizer = MemorySummarizer(mock_agent, **memory_services)
+    summary = await summarizer.summarize_thread("C123", "1234567890.123456")
+    assert summary.title is not None
+    assert summary.summary is not None
+
+
+@pytest.mark.asyncio
+async def test_summarize_channel_daily(mock_agent, memory_services):
+    """チャンネル日次要約が正しく生成されること"""
+
+
+# tests/memory/test_batch_processor.py
+
+@pytest.mark.asyncio
+async def test_batch_processor_start_stop():
+    """バッチ処理の開始と停止"""
+    processor = BatchProcessor(...)
+    await processor.start()
+    assert processor._running
+    await processor.stop()
+    assert not processor._running
+
+
+@pytest.mark.asyncio
+async def test_run_once():
+    """バッチ処理の1回実行"""
+
+
+@pytest.mark.asyncio
+async def test_process_channel_with_changes():
+    """変更があるチャンネルの処理"""
+
+
+@pytest.mark.asyncio
+async def test_process_channel_without_changes():
+    """変更がないチャンネルの処理（スキップ）"""
+
+
+@pytest.mark.asyncio
+async def test_error_handling():
+    """エラー発生時の処理継続"""
+```
+
+### モック戦略
+
+```python
+@pytest.fixture
+def mock_agent(mocker):
+    """NyaoAgentのモック"""
+    agent = mocker.MagicMock(spec=NyaoAgent)
+    agent.call_llm_with_structured_output = AsyncMock(
+        return_value=ThreadSummary(...)
+    )
+    return agent
+```
+
+---
+
+## エラーハンドリング
+
+### リトライ戦略
+
+- LLM API呼び出しは既存のリトライ機能を使用
+- チャンネル処理でエラーが発生した場合、そのチャンネルをスキップして次のチャンネルを処理
+- バッチ処理全体でエラーが発生した場合、次の実行まで待機
+
+### ログ出力
+
+```python
+async def _process_channel(self, channel_id: str) -> ChannelBatchResult:
+    logger.info("Processing channel", channel_id=channel_id)
+    try:
+        # 処理...
+        logger.info(
+            "Channel processed",
+            channel_id=channel_id,
+            today_updated=result.today_summary_updated,
+            missing_created=result.missing_summaries_created,
+        )
+        return result
+    except Exception as e:
+        logger.error(
+            "Failed to process channel",
+            channel_id=channel_id,
+            error=str(e),
+        )
+        return ChannelBatchResult(
+            channel_id=channel_id,
+            today_summary_updated=False,
+            missing_summaries_created=0,
+            thread_summaries_updated=0,
+            errors=[str(e)],
+        )
+```
+
+---
+
+## 完了条件
+
+- [ ] MemorySummarizerが実装されていること
+  - [ ] スレッド要約生成が動作すること
+  - [ ] チャンネル日次要約生成が動作すること
+  - [ ] 長期記憶更新が動作すること
+- [ ] BatchProcessorが実装されていること
+  - [ ] 定期実行が動作すること
+  - [ ] 変更検知が動作すること
+  - [ ] 欠落要約の作成が動作すること
+  - [ ] グレースフルシャットダウンが動作すること
+- [ ] NyaoBotに統合されていること
+- [ ] 全テストがパスすること
+- [ ] ruff、tyによるチェックがパスすること

--- a/specs/phase-2/README.md
+++ b/specs/phase-2/README.md
@@ -253,8 +253,6 @@ class ChannelLongTermMemory(SQLModel, table=True):
     channel_name: str
     purpose: str
     typical_topics: list[str] = Field(sa_type=JSON)
-    communication_style: str
-    activity_pattern: str
     historical_summary: str = Field(sa_column=Column(Text))
     important_events: list[dict] = Field(sa_type=JSON)
     last_updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -270,8 +268,6 @@ class UserLongTermMemory(SQLModel, table=True):
     user_name: str
     interests: list[str] = Field(sa_type=JSON)
     expertise: list[str] = Field(sa_type=JSON)
-    communication_style: str
-    frequent_channels: list[str] = Field(sa_type=JSON)
     last_updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
 ```
 
@@ -352,6 +348,12 @@ class UserLongTermMemory(SQLModel, table=True):
 ## ドキュメント構成
 
 - [README.md](./README.md) - 本ドキュメント（Phase 2全体像）
+- [implementation-plan.md](./implementation-plan.md) - 実装計画（Week 1-4）
+- [01-litellm-migration.md](./01-litellm-migration.md) - LiteLLM直接使用への移行設計
+- [02-smart-response.md](./02-smart-response.md) - スマート応答判定設計
+- [03-memory-models.md](./03-memory-models.md) - 階層的記憶のデータモデル設計
+- [04-memory-services.md](./04-memory-services.md) - 記憶管理サービス設計
+- [05-batch-processing.md](./05-batch-processing.md) - 日次要約バッチ処理設計
 
 ## 参考資料
 

--- a/specs/phase-2/implementation-plan.md
+++ b/specs/phase-2/implementation-plan.md
@@ -1,0 +1,577 @@
+# Phase 2 実装計画
+
+## 概要
+
+Phase 2の実装を効率的に進めるための詳細な計画とタスク分割を記載します。LiteLLM直接使用への移行を基盤として、スマート応答判定と階層的記憶管理システムを約4週間で完成させることを目指します。
+
+## 実装スケジュール概要
+
+```
+Week 1: Phase 2.1 - LiteLLM直接使用への移行
+Week 2: Phase 2.2-2.3 - スマート応答判定（jitter、再判定、返信先判定）
+Week 3: Phase 2.4 - 階層的記憶管理（データモデル + サービス）
+Week 4: Phase 2.4 - 日次要約バッチ + 統合テスト
+```
+
+---
+
+## Week 1: LiteLLM直接使用への移行（Phase 2.1）
+
+### 目標
+
+strands-agentsを削除し、LiteLLMの`acompletion`を直接使用するエージェント基盤を実装する。
+
+### Day 1-2: 新NyaoAgentクラスの実装
+
+#### タスク
+
+1. **NyaoAgentクラスのリファクタリング**
+   - `integrations/llm/agent_base.py` の書き換え
+   - `strands.Agent` への依存を削除
+   - `litellm.acompletion` を直接使用
+   - `call_llm()` メソッドの再実装
+
+2. **構造化出力メソッドの実装**
+   - `call_llm_with_structured_output()` の実装
+   - JSON出力を要求するプロンプト修正
+   - Pydanticモデルへのパース処理
+
+3. **エラーハンドリングとリトライ**
+   - 既存のリトライロジックを移植
+   - `LLMAPIError` の活用
+   - タイムアウト処理
+
+4. **テストの作成**
+   ```bash
+   uv run pytest tests/integrations/llm/test_agent_base.py
+   ```
+
+**完了基準**:
+- [ ] `NyaoAgent.call_llm()` が動作すること
+- [ ] `NyaoAgent.call_llm_with_structured_output()` が動作すること
+- [ ] リトライ機能が動作すること
+- [ ] すべてのテストがパスすること
+
+---
+
+### Day 3: ResponseJudgeAgentの更新
+
+#### タスク
+
+1. **ResponseJudgeAgentの更新**
+   - `integrations/llm/judge_agent.py` の更新
+   - `call_llm_with_structured_output()` を使用した応答判定
+   - `ResponseDecision` モデルを使用した構造化出力
+
+2. **プロンプトの調整**
+   - JSON出力形式の明示的な指定
+   - 出力スキーマの記述
+
+3. **テストの作成**
+   ```bash
+   uv run pytest tests/integrations/llm/test_judge_agent.py
+   ```
+
+**完了基準**:
+- [ ] 応答判定が正しく動作すること
+- [ ] JSONパースが正常に動作すること
+- [ ] 既存のテストがパスすること
+
+---
+
+### Day 4: ResponseGeneratorAgentの更新
+
+#### タスク
+
+1. **ResponseGeneratorAgentの更新**
+   - `integrations/llm/generator_agent.py` の更新
+   - `call_llm()` を使用した応答生成
+   - フォールバック処理の維持
+
+2. **テストの作成**
+   ```bash
+   uv run pytest tests/integrations/llm/test_generator_agent.py
+   ```
+
+**完了基準**:
+- [ ] 応答生成が正しく動作すること
+- [ ] フォールバック処理が動作すること
+- [ ] 既存のテストがパスすること
+
+---
+
+### Day 5: strands-agents依存の削除と統合テスト
+
+#### タスク
+
+1. **依存関係の削除**
+   - `pyproject.toml` から `strands-agents` を削除
+   - 関連するインポートの削除
+
+2. **全テストの確認**
+   ```bash
+   uv run pytest
+   uv run ruff check .
+   uv run ruff format --check .
+   uv run ty check .
+   ```
+
+3. **動作確認**
+   - ローカル環境での起動テスト
+   - Slack APIへの接続確認
+
+**完了基準**:
+- [ ] strands-agents依存が完全に削除されていること
+- [ ] すべてのテストがパスすること
+- [ ] ruff、tyによるチェックがパスすること
+
+### Week 1 完了チェック
+
+- [ ] NyaoAgentがLiteLLMを直接使用していること
+- [ ] call_llm_with_structured_outputが実装されていること
+- [ ] strands-agentsへの依存がないこと
+- [ ] 全テストがパスすること
+
+---
+
+## Week 2: スマート応答判定（Phase 2.2-2.3）
+
+### 目標
+
+リクエストごとのjitter適用、再判定機能、返信先判定を実装する。
+
+### Day 1-2: jitter毎回計算対応（FR-603）
+
+#### タスク
+
+1. **ResponseDelayControllerの更新**
+   - `services/delay_controller.py` の更新
+   - `schedule_response_check()` 呼び出し時に毎回jitterを計算
+   - 既存のコンストラクタでの一回計算を削除
+
+2. **設定の確認**
+   - `BotSettings.response_delay` の設定確認
+   - jitter範囲の調整
+
+3. **テストの作成**
+   ```bash
+   uv run pytest tests/services/test_delay_controller.py
+   ```
+
+**完了基準**:
+- [ ] リクエストごとにjitterが適用されること
+- [ ] 遅延時間がランダムに変動すること
+- [ ] テストがパスすること
+
+---
+
+### Day 3-4: 再判定機能（FR-601）
+
+#### タスク
+
+1. **RejudgeTrackerクラスの実装**
+   - `services/rejudge_tracker.py` の新規作成
+   - 「返答不要」判定されたメッセージの追跡
+   - 再判定回数のカウント
+   - 最大再判定回数の管理
+
+2. **設定の追加**
+   - `config/settings.py` に `RejudgeSettings` を追加
+   ```python
+   class RejudgeSettings(BaseModel):
+       interval_seconds: int = 300  # 5分後に再判定
+       max_count: int = 3  # 最大3回まで再判定
+   ```
+
+3. **NyaoBotへの統合**
+   - `main.py` の `_check_and_respond()` を更新
+   - 「返答不要」判定後、再判定スケジュールを設定
+   - 新メッセージ受信時の再判定キャンセル
+
+4. **テストの作成**
+   ```bash
+   uv run pytest tests/services/test_rejudge_tracker.py
+   ```
+
+**完了基準**:
+- [ ] 再判定機能が動作すること
+- [ ] 新メッセージで再判定がスキップされること
+- [ ] 最大回数で再判定が停止すること
+- [ ] テストがパスすること
+
+---
+
+### Day 5: 返信先判定（FR-602）
+
+#### タスク
+
+1. **ReplyTarget enumの追加**
+   - `core/models.py` に追加
+   ```python
+   class ReplyTarget(str, Enum):
+       THREAD = "thread"
+       CHANNEL = "channel"
+   ```
+
+2. **ResponseDecisionモデルの拡張**
+   ```python
+   class ResponseDecision(BaseModel):
+       should_respond: bool
+       reason: str
+       confidence: float
+       suggested_delay_minutes: int | None = None
+       reply_target: ReplyTarget = ReplyTarget.THREAD
+   ```
+
+3. **プロンプトの更新**
+   - `integrations/llm/prompts.py` の更新
+   - 返信先判定の指示を追加
+   - 判定基準の明示
+
+4. **NyaoBotの更新**
+   - `_check_and_respond()` の更新
+   - `reply_target` に基づいて送信先を決定
+
+5. **テストの作成**
+   ```bash
+   uv run pytest tests/integrations/llm/test_judge_agent.py
+   uv run pytest tests/test_main.py
+   ```
+
+**完了基準**:
+- [ ] 返信先判定が正しく動作すること
+- [ ] スレッドへの返信が動作すること
+- [ ] チャンネルへの直接投稿が動作すること
+- [ ] テストがパスすること
+
+### Week 2 完了チェック
+
+- [ ] リクエストごとにjitterが適用されていること
+- [ ] 再判定機能が動作していること
+- [ ] 返信先判定が動作していること
+- [ ] 全テストがパスすること
+
+---
+
+## Week 3: 階層的記憶管理システム - データモデル + サービス（Phase 2.4 前半）
+
+### 目標
+
+SQLModelを使用したデータモデルと記憶層サービスを実装する。
+
+### Day 1-2: データモデル定義とデータベース初期化
+
+#### タスク
+
+1. **memoryディレクトリの作成**
+   ```bash
+   mkdir -p nyao/memory
+   touch nyao/memory/__init__.py
+   ```
+
+2. **データモデルの実装**
+   - `memory/models.py` の作成
+   - `WorkingMemoryMessage`
+   - `ThreadSummary`
+   - `ChannelDailySummary`
+   - `WorkspaceMemory`
+   - `ChannelLongTermMemory`
+   - `UserLongTermMemory`
+
+3. **データベース初期化**
+   - `memory/database.py` の作成
+   - SQLite接続管理
+   - テーブル作成
+   - 非同期セッション管理
+
+4. **依存パッケージの追加**
+   ```bash
+   uv add sqlmodel aiosqlite
+   ```
+
+5. **テストの作成**
+   ```bash
+   uv run pytest tests/memory/test_models.py
+   uv run pytest tests/memory/test_database.py
+   ```
+
+**完了基準**:
+- [ ] すべてのモデルが定義されていること
+- [ ] データベースが正しく初期化されること
+- [ ] CRUD操作が動作すること
+- [ ] テストがパスすること
+
+---
+
+### Day 3-4: 記憶層サービスの実装
+
+#### タスク
+
+1. **ワーキングメモリサービス**
+   - `memory/working_memory.py` の作成
+   - メッセージの保存・取得
+   - LiteLLMメッセージ形式への変換
+   - 過去X日分のフィルタリング
+   - 古いメッセージの削除
+
+2. **短期記憶サービス**
+   - `memory/short_term.py` の作成
+   - スレッド要約の保存・取得
+   - チャンネル日次要約の保存・取得
+
+3. **長期記憶サービス**
+   - `memory/long_term.py` の作成
+   - ワークスペース記憶の保存・取得
+   - チャンネル特性の保存・取得
+   - ユーザー特性の保存・取得
+
+4. **テストの作成**
+   ```bash
+   uv run pytest tests/memory/test_working_memory.py
+   uv run pytest tests/memory/test_short_term.py
+   uv run pytest tests/memory/test_long_term.py
+   ```
+
+**完了基準**:
+- [ ] 各記憶層のCRUD操作が動作すること
+- [ ] LiteLLMメッセージ形式への変換が正しいこと
+- [ ] テストがパスすること
+
+---
+
+### Day 5: MemoryContextBuilderの実装
+
+#### タスク
+
+1. **MemoryContextBuilderの実装**
+   - `memory/context_builder.py` の作成
+   - 階層的記憶を組み合わせてプロンプトコンテキストを構築
+   - トークン数の推定と制限（8000トークン以内）
+   - 優先順位に基づく記憶の選択
+
+2. **既存サービスとの統合準備**
+   - `ContextManagerService` との連携方針決定
+   - インメモリ管理からDB永続化への段階的移行
+
+3. **テストの作成**
+   ```bash
+   uv run pytest tests/memory/test_context_builder.py
+   ```
+
+**完了基準**:
+- [ ] プロンプトコンテキストが正しく構築されること
+- [ ] トークン数制限が守られること
+- [ ] テストがパスすること
+
+### Week 3 完了チェック
+
+- [ ] すべてのデータモデルが定義されていること
+- [ ] データベース初期化が動作すること
+- [ ] 各記憶層サービスが動作すること
+- [ ] MemoryContextBuilderが動作すること
+- [ ] 全テストがパスすること
+
+---
+
+## Week 4: 日次要約バッチ + 統合テスト（Phase 2.4 後半）
+
+### 目標
+
+要約生成機能とバッチ処理を実装し、全体を統合する。
+
+### Day 1-2: MemorySummarizerの実装
+
+#### タスク
+
+1. **MemorySummarizerの実装**
+   - `memory/summarizer.py` の作成
+   - スレッド要約生成
+   - チャンネル日次要約生成
+   - ワークスペース要約更新
+   - チャンネル特性更新
+   - ユーザー特性更新
+
+2. **プロンプトテンプレートの作成**
+   - `integrations/llm/prompts.py` に要約用プロンプトを追加
+   - スレッド要約用
+   - チャンネル日次要約用
+   - チャンネル特性抽出用
+   - ユーザー特性抽出用
+
+3. **テストの作成**
+   ```bash
+   uv run pytest tests/memory/test_summarizer.py
+   ```
+
+**完了基準**:
+- [ ] 各種要約が正しく生成されること
+- [ ] LLMを使用した要約が動作すること
+- [ ] テストがパスすること
+
+---
+
+### Day 3: 日次要約バッチ処理
+
+#### タスク
+
+1. **BatchProcessorの実装**
+   - `memory/batch_processor.py` の作成
+   - 10分間隔での実行ループ
+   - チャンネルごとの変更検知（最終更新時刻を追跡）
+   - 当日分の更新処理
+   - 過去X日分の作成処理
+
+2. **NyaoBotへの統合**
+   - `main.py` の更新
+   - バッチ処理ループの起動
+   - グレースフルシャットダウン対応
+
+3. **テストの作成**
+   ```bash
+   uv run pytest tests/memory/test_batch_processor.py
+   ```
+
+**完了基準**:
+- [ ] バッチ処理が正常に実行されること
+- [ ] 変更検知が動作すること
+- [ ] グレースフルシャットダウンが動作すること
+- [ ] テストがパスすること
+
+---
+
+### Day 4-5: 統合テストと最終調整
+
+#### タスク
+
+1. **統合テストの実施**
+   - メッセージ受信から応答送信までのフルフロー
+   - 記憶管理の統合テスト
+   - 再判定機能の統合テスト
+
+2. **パフォーマンス確認**
+   - コンテキスト構築時間の測定
+   - トークン使用量の確認
+   - データベースクエリの最適化
+
+3. **コード品質チェック**
+   ```bash
+   uv run ruff check .
+   uv run ruff format --check .
+   uv run ty check .
+   uv run pytest --cov=nyao
+   ```
+
+4. **ドキュメントの整備**
+   - README.mdの更新（Phase 2完了を反映）
+
+**完了基準**:
+- [ ] 過去の会話を踏まえた応答が50%以上
+- [ ] コンテキストウィンドウが8000トークン以内
+- [ ] すべてのテストがパスすること
+- [ ] ruff、tyによるチェックがパスすること
+
+### Week 4 完了チェック
+
+- [ ] MemorySummarizerが動作すること
+- [ ] BatchProcessorが動作すること
+- [ ] 統合テストがパスすること
+- [ ] 全テストがパスすること
+
+---
+
+## テスト戦略
+
+### ユニットテスト
+
+- 各コンポーネントごとに独立したテスト
+- モックを使用して外部依存を排除
+- カバレッジ80%以上を目標
+
+### 統合テスト
+
+- コンポーネント間の連携をテスト
+- SQLiteを使用した実際のDB操作テスト
+- LLM APIはモックを使用
+
+### テスト実行コマンド
+
+```bash
+# すべてのテスト
+uv run pytest
+
+# 特定のモジュールのテスト
+uv run pytest tests/memory/
+uv run pytest tests/services/
+
+# カバレッジレポート
+uv run pytest --cov=nyao --cov-report=html
+
+# コード品質チェック
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check .
+```
+
+---
+
+## 依存パッケージ
+
+### 追加するパッケージ
+
+```toml
+[project.dependencies]
+sqlmodel = ">=0.0.22"
+aiosqlite = ">=0.19.0"
+# litellmは既存（strands-agents経由で入っていたものを直接依存に変更）
+litellm = ">=1.0.0"
+
+[dependency-groups.dev]
+# 既存のパッケージに加えて
+pytest-asyncio = ">=0.23.0"
+```
+
+### 削除するパッケージ
+
+```toml
+# 削除対象
+strands-agents = "..."  # Week 1 Day 5 で削除
+```
+
+---
+
+## リスク管理
+
+| リスク | 影響 | 対策 |
+|--------|------|------|
+| LiteLLM APIの変更 | 中 | バージョン固定、テスト充実 |
+| トークン数超過 | 高 | 段階的な記憶圧縮、優先順位管理 |
+| SQLiteパフォーマンス | 低 | インデックス最適化、クエリ効率化 |
+| バッチ処理の負荷 | 中 | 処理間隔の調整、並行処理の検討 |
+
+---
+
+## 成功基準（再掲）
+
+- [ ] strands-agents依存が完全に削除されている
+- [ ] リクエストごとにjitterが適用されている
+- [ ] 再判定機能が動作している
+- [ ] 返信先判定が正しく動作している
+- [ ] 階層的記憶管理が動作し、プロンプトに反映されている
+- [ ] 日次要約バッチが正常に実行されている
+- [ ] 過去の会話を踏まえた応答が50%以上
+- [ ] コンテキストウィンドウの効率的な使用（8000トークン以内）
+- [ ] 既存のテストがすべてパスしている
+- [ ] ruff、tyによるコード品質チェックがパスしている
+
+---
+
+## 参考資料
+
+- [プロジェクト要求仕様書](../../requirements.md)
+- [Phase 2 README](./README.md)
+- 各レイヤーの詳細仕様
+  - [01-litellm-migration.md](./01-litellm-migration.md)
+  - [02-smart-response.md](./02-smart-response.md)
+  - [03-memory-models.md](./03-memory-models.md)
+  - [04-memory-services.md](./04-memory-services.md)
+  - [05-batch-processing.md](./05-batch-processing.md)


### PR DESCRIPTION
## Summary

Phase 2の実装計画と詳細設計書を追加します。

### 作成したドキュメント

- **implementation-plan.md** - Week 1-4の実装計画、タスク分割、完了基準
- **01-litellm-migration.md** - LiteLLM直接使用への移行設計（strands-agents削除）
- **02-smart-response.md** - スマート応答判定設計（jitter、再判定、返信先判定）
- **03-memory-models.md** - 階層的記憶のデータモデル設計（SQLModel）
- **04-memory-services.md** - 記憶管理サービス設計
- **05-batch-processing.md** - 日次要約バッチ処理設計

### 実装スケジュール

- Week 1: LiteLLM直接使用への移行
- Week 2: スマート応答判定（jitter、再判定、返信先判定）
- Week 3: 階層的記憶管理（データモデル + サービス）
- Week 4: 日次要約バッチ + 統合テスト

## Test plan

- [x] すべてのMarkdownファイルが正しい形式であること
- [x] 各設計書がPhase 1のパターンに従っていること
- [x] README.mdのドキュメント構成セクションが更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)